### PR TITLE
check in tests

### DIFF
--- a/R/define_boot_table.R
+++ b/R/define_boot_table.R
@@ -87,7 +87,8 @@ define_boot_table <- function(.boot_estimates, .nonboot_estimates, .key){
   checkTransforms() %>%
   defineRows() %>%
   backTrans_log() %>%
-  backTrans_logit()
+  backTrans_logit() %>%
+  dplyr::arrange(nrow)
 
 .boot_df
 

--- a/R/define_boot_table.R
+++ b/R/define_boot_table.R
@@ -88,7 +88,7 @@ define_boot_table <- function(.boot_estimates, .nonboot_estimates, .key){
   defineRows() %>%
   backTrans_log() %>%
   backTrans_logit() %>%
-  dplyr::arrange(nrow)
+  dplyr::arrange(as.numeric(nrow))
 
 .boot_df
 

--- a/R/define_param_table.R
+++ b/R/define_param_table.R
@@ -53,7 +53,8 @@ define_param_table <- function(.estimates, .key, .ci = 95, .zscore = NULL){
     checkTransforms() %>%
     defineRows() %>%
     getValueSE() %>%
-    getCI(.ci = .ci, .zscore = .zscore)
+    getCI(.ci = .ci, .zscore = .zscore) %>%
+    dplyr::arrange("nrow")
 
   return(mod_estimates)
 }

--- a/R/define_param_table.R
+++ b/R/define_param_table.R
@@ -54,7 +54,7 @@ define_param_table <- function(.estimates, .key, .ci = 95, .zscore = NULL){
     defineRows() %>%
     getValueSE() %>%
     getCI(.ci = .ci, .zscore = .zscore) %>%
-    dplyr::arrange("nrow")
+    dplyr::arrange(as.numeric(nrow))
 
   return(mod_estimates)
 }

--- a/R/format_boot_table.R
+++ b/R/format_boot_table.R
@@ -39,7 +39,8 @@ format_boot_table <- function(.boot_df,
   .digit = ifelse(is.null(.digit), formals(pmtables::sig)$digits, .digit)
 
   .df_out <- .boot_df %>%
-    formatValuesBoot()
+    formatValuesBoot() %>%
+    dplyr::arrange("nrow")
 
   if (any(tolower(.select_cols) == "all")) {
     return(.df_out %>% as.data.frame())

--- a/R/format_boot_table.R
+++ b/R/format_boot_table.R
@@ -40,7 +40,8 @@ format_boot_table <- function(.boot_df,
 
   .df_out <- .boot_df %>%
     formatValuesBoot() %>%
-    dplyr::arrange("nrow")
+    dplyr::arrange(as.numeric(nrow)) %>%
+    dplyr::select(-nrow)
 
   if (any(tolower(.select_cols) == "all")) {
     return(.df_out %>% as.data.frame())

--- a/R/format_param_table.R
+++ b/R/format_param_table.R
@@ -55,7 +55,7 @@ format_param_table <- function(.df,
     formatValues(.digit = .digit, .maxex = .maxex) %>%
     formatGreekNames() %>%
     getPanelName() %>%
-    dplyr::arrange("nrow")
+    dplyr::arrange(as.numeric(nrow))
 
   if (any(tolower(.select_cols) == "all")) {
     return(.df_out %>% as.data.frame())

--- a/R/format_param_table.R
+++ b/R/format_param_table.R
@@ -55,7 +55,8 @@ format_param_table <- function(.df,
     formatValues(.digit = .digit, .maxex = .maxex) %>%
     formatGreekNames() %>%
     getPanelName() %>%
-    dplyr::arrange(as.numeric(nrow))
+    dplyr::arrange(as.numeric(nrow)) %>%
+    dplyr::select(-nrow)
 
   if (any(tolower(.select_cols) == "all")) {
     return(.df_out %>% as.data.frame())

--- a/R/format_param_table.R
+++ b/R/format_param_table.R
@@ -54,7 +54,8 @@ format_param_table <- function(.df,
     .df %>%
     formatValues(.digit = .digit, .maxex = .maxex) %>%
     formatGreekNames() %>%
-    getPanelName()
+    getPanelName() %>%
+    dplyr::arrange("nrow")
 
   if (any(tolower(.select_cols) == "all")) {
     return(.df_out %>% as.data.frame())

--- a/R/loadParamKey.R
+++ b/R/loadParamKey.R
@@ -34,5 +34,8 @@ loadParamKey <- function(.key){
     stop("Incorrect parameter key input type. See ?param_key for list of valid parameter key inputs")
   }
 
-  .key
+  .key %>%
+    dplyr::mutate(
+      nrow = 1:dplyr::n()
+    )
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -31,6 +31,9 @@ paramKey = dplyr::tribble(
   "SIGMA11", "Proportional", "Variance", "RV", "propErr"
 )
 
+paramKey2 <-  system.file("model/nonmem/pk-parameter-key-new.yaml", package = "pmparams")
+param_yaml <- yaml::yaml.load_file(paramKey2)
+
 #Data for testing param table (no boot)
 
 paramPath <- system.file("model/nonmem/102", package = "pmparams")

--- a/tests/testthat/test-define_param_table.R
+++ b/tests/testthat/test-define_param_table.R
@@ -76,7 +76,7 @@ test_that("define_param_table incorrect parameter key input type: Only abb, desc
 test_that("define_param_table generates correct corr_SD", {
   expect_true(all(newDF$estimate == newDF$value))
   expect_true(all(newDF$stderr == newDF$se))
-  expect_true(newDF$corr_SD[7] == "0.511")
+  expect_true(newDF$corr_SD[9] == "0.511")
   expect_true(newDF$corr_SD[1] == "-")
   expect_true(newDF$corr_SD[6] == "-")
 })
@@ -89,7 +89,13 @@ test_that("define_param_table generates the confidence intervals for various inp
   expect_equal(newDF_ci90$upper[2], 4.1640688)
 
   expect_equal(newDF_ci95$lower[4], 4.1721829)
-  expect_equal(newDF_ci95$upper[7], 0.108133732)
+  expect_equal(newDF_ci95$upper[7], 0.10195012)
 })
 
+test_that("define_param_table expected dataframe: respects yaml key order",{
+  paramKey2 <- paramKey %>%
+    filter(name %in% newDF$name)
+
+  expect_equal(newDF$name, paramKey2$name)
+})
 

--- a/tests/testthat/test-format_boot_table.R
+++ b/tests/testthat/test-format_boot_table.R
@@ -10,7 +10,7 @@ test_that("format_boot_table expected dataframe: col names", {
   expect_equal(names(newDF3),  c("abb", "desc", "boot_value", "boot_ci"))
 
   #all cols
-  expect_equal(length(names(newDF5)),  25)
+  expect_equal(length(names(newDF5)),  24)
 })
 
 
@@ -25,3 +25,4 @@ test_that("format_boot_table expected dataframe: respects yaml key order", {
   expect_equal(unname(unlist(param_yaml))[grepl('desc',names(unlist(param_yaml)),fixed=T) & unlist(param_yaml) %in% newDF3$desc],
                newDF3$desc)
 })
+

--- a/tests/testthat/test-format_boot_table.R
+++ b/tests/testthat/test-format_boot_table.R
@@ -10,7 +10,7 @@ test_that("format_boot_table expected dataframe: col names", {
   expect_equal(names(newDF3),  c("abb", "desc", "boot_value", "boot_ci"))
 
   #all cols
-  expect_equal(length(names(newDF5)),  24)
+  expect_equal(length(names(newDF5)),  25)
 })
 
 
@@ -21,3 +21,7 @@ test_that("format_param_table continuous columns expected ouput: value", {
   expect_equal(newDF3$boot_value[6], "0.484")
 })
 
+test_that("format_boot_table expected dataframe: respects yaml key order", {
+  expect_equal(unname(unlist(param_yaml))[grepl('desc',names(unlist(param_yaml)),fixed=T) & unlist(param_yaml) %in% newDF3$desc],
+               newDF3$desc)
+})

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -48,7 +48,7 @@ test_that("format_param_table continuous columns expected ouput: shrinkage", {
 
   expect_equal(newDF_shrink$shrinkage[1], "-")
   expect_equal(newDF_shrink$shrinkage[6], "17.9")
-  expect_equal(newDF_shrink$shrinkage[8], "6.02")
+  expect_equal(newDF_shrink$shrinkage[8], "0.587")
 })
 
 test_that("format_param_table continuous columns expected ouput: value", {

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -16,7 +16,7 @@ test_that("format_param_table expected dataframe: col names", {
   expect_equal(names(newDF3),  c("type", "abb", "greek", "desc", "value", "ci", "shrinkage"))
 
   #all cols., no prse
-  expect_equal(length(names(newDF5)),  39) #check this
+  expect_equal(length(names(newDF5)),  40)
 })
 
 test_that("format_param_table expected dataframe: prse col", {
@@ -54,5 +54,10 @@ test_that("format_param_table continuous columns expected ouput: shrinkage", {
 test_that("format_param_table continuous columns expected ouput: value", {
   expect_equal(newDF3$value[1], "1.54")
   expect_equal(newDF3$value[6], "0.221 [CV\\%=49.7]")
+})
+
+test_that("format_param_table expected dataframe: respects yaml key order", {
+  expect_equal(unname(unlist(param_yaml))[grepl('desc',names(unlist(param_yaml)),fixed=T) & unlist(param_yaml) %in% newDF3$desc],
+               newDF3$desc)
 })
 

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -16,7 +16,7 @@ test_that("format_param_table expected dataframe: col names", {
   expect_equal(names(newDF3),  c("type", "abb", "greek", "desc", "value", "ci", "shrinkage"))
 
   #all cols., no prse
-  expect_equal(length(names(newDF5)),  40)
+  expect_equal(length(names(newDF5)),  39)
 })
 
 test_that("format_param_table expected dataframe: prse col", {


### PR DESCRIPTION
This PR does the following:

Make parameter table rows respect the ordering in the yaml file.

- pull the key in
- add row numbers
- do the inner join
- arrange by the row number column from the key
- drop the row number column and continue on as normal