### PR TITLE
Add addErrLogDV transform option

### DIFF
--- a/R/defineRows.R
+++ b/R/defineRows.R
@@ -12,7 +12,7 @@
 #' @keywords internal
 defineRows <- function(.df){
 
-  transList <- c("logTrans", "logitTrans", "lognormalOm", "OmSD", "propErr", "addErr", "none")
+  transList <- c("logTrans", "logitTrans", "lognormalOm", "OmSD", "propErr", "addErr", "addErrLogDV", "none")
   mismatch <- .df %>% dplyr::filter(!(stringr::str_detect(trans, paste(transList, collapse="|"))))
 
   if(nrow(mismatch) > 0) {
@@ -30,7 +30,8 @@ defineRows <- function(.df){
       Osd = (trans=="OmSD"),
       logitOsd = (trans=="logitOmSD"),
       propErr = (trans=="propErr"),
-      addErr = (trans=="addErr")
+      addErr = (trans=="addErr"),
+      addErrLogDV = (trans == "addErrLogDV")
     )
 }
 

--- a/R/define_boot_table.R
+++ b/R/define_boot_table.R
@@ -73,7 +73,7 @@ define_boot_table <- function(.boot_estimates, .nonboot_estimates, .key){
 #clean up boot
 .bootParam = .boot %>%
     bbr::param_estimates_compare() %>%
-    dplyr::rename(estimate = "50%", lower = "2.5%", upper = "97.5%") %>%
+    dplyr::rename(estimate = "p50", lower = "p2.5", upper = "p97.5") %>%
     dplyr::mutate(name = gsub("[[:punct:]]", "", parameter_names)) %>%
     dplyr::inner_join(.key, by = "name")
 

--- a/R/formatValues.R
+++ b/R/formatValues.R
@@ -25,6 +25,7 @@ formatValues <- function(.df,
       value = dplyr::case_when(
         diag & OM & Osd | diag & OM & logitOsd ~ glue::glue("{value} {parensSQ_se(sd)}"),
         diag & OM | diag & S & propErr ~ glue::glue("{value} {parensSQ_CV(cv)}"),
+        diag & OM | diag & S & addErrLogDV ~ glue::glue("{value} {parensSQ_CV(cv)}"),
         !diag & OM ~ glue::glue("{value} {parensSQ_corr(corr_SD)}"),
         diag & S & addErr ~ glue::glue("{value} {parensSQ_se(corr_SD)}"),
         !diag & S ~ glue::glue("{value} {parensSQ_corr(corr_SD)}"),

--- a/R/getpCV.R
+++ b/R/getpCV.R
@@ -5,7 +5,7 @@ getpCV <- function(.df){
       cv = dplyr::case_when(
         diag & OM & lognormO ~ pmtables::sig(getCV_lognormO(value)),
         diag & S & propErr ~ pmtables::sig(getCV_propS(value)),
-        diag & S & addErrLogDV ~ pmtables::sig(getCV_propS(value)),
+        diag & S & addErrLogDV ~ pmtables::sig(getCV_lognormO(value)),
         TRUE ~ "-")
       ) %>%
     suppressWarnings()

--- a/R/getpCV.R
+++ b/R/getpCV.R
@@ -5,6 +5,7 @@ getpCV <- function(.df){
       cv = dplyr::case_when(
         diag & OM & lognormO ~ pmtables::sig(getCV_lognormO(value)),
         diag & S & propErr ~ pmtables::sig(getCV_propS(value)),
+        diag & S & addErrLogDV ~ pmtables::sig(getCV_lognormO(value)),
         TRUE ~ "-")
       ) %>%
     suppressWarnings()

--- a/R/getpCV.R
+++ b/R/getpCV.R
@@ -5,7 +5,7 @@ getpCV <- function(.df){
       cv = dplyr::case_when(
         diag & OM & lognormO ~ pmtables::sig(getCV_lognormO(value)),
         diag & S & propErr ~ pmtables::sig(getCV_propS(value)),
-        diag & S & addErrLogDV ~ pmtables::sig(getCV_lognormO(value)),
+        diag & S & addErrLogDV ~ pmtables::sig(getCV_propS(value)),
         TRUE ~ "-")
       ) %>%
     suppressWarnings()

--- a/R/param-key.R
+++ b/R/param-key.R
@@ -31,6 +31,7 @@
 #'   - "logitOmSD"  - for omegas using logit transform - returns estimate & SD (calculated with logitnorm package); this option requires you provide the associated THETA separated with a "~"; e.g. "logitOmSD ~ THETA3"
 #'   - "addErr"     - for additive error terms (coded using SIGMA in $ERROR) - returns est.+ SD
 #'   - "propErr"    - for proportional error terms (coded using SIGMA in $ERROR) - returns est.+CV%
+#'   - "addErrLogDV" - for additive error log terms (coded using SIGMA in $ERROR) - returns est.+CV%
 #'
 #' # YAML Example
 #'

--- a/inst/model/nonmem/pk-parameter-key-both.yaml
+++ b/inst/model/nonmem/pk-parameter-key-both.yaml
@@ -28,6 +28,7 @@
 ##'                     - e.g. "logitOmSD ~ THETA3"
 ##'        "addErr"     - for additive error terms (coded using SIGMA in $ERROR) - returns est.+ SD
 ##'        "propErr"    - for proportional error terms (coded using SIGMA in $ERROR) - returns est.+CV%
+##'        "addErrLogDV" - for additive error log terms (coded using SIGMA in $ERROR) - returns est.+CV%
 #
 # paramKey = tribble(
 #   ~name, ~abb, ~desc, ~panel, ~trans,

--- a/inst/model/nonmem/pk-parameter-key-new.yaml
+++ b/inst/model/nonmem/pk-parameter-key-new.yaml
@@ -28,6 +28,7 @@
 ##'                     - e.g. "logitOmSD ~ THETA3"
 ##'        "addErr"     - for additive error terms (coded using SIGMA in $ERROR) - returns est.+ SD
 ##'        "propErr"    - for proportional error terms (coded using SIGMA in $ERROR) - returns est.+CV%
+##'        "addErrLogDV" - for additive error log terms (coded using SIGMA in $ERROR) - returns est.+CV%
 #
 # paramKey = tribble(
 #   ~name, ~abb, ~desc, ~panel, ~trans,

--- a/inst/model/nonmem/pk-parameter-key.yaml
+++ b/inst/model/nonmem/pk-parameter-key.yaml
@@ -28,6 +28,7 @@
 ##'                     - e.g. "logitOmSD ~ THETA3"
 ##'        "addErr"     - for additive error terms (coded using SIGMA in $ERROR) - returns est.+ SD
 ##'        "propErr"    - for proportional error terms (coded using SIGMA in $ERROR) - returns est.+CV%
+##'        "addErrLogDV" - for additive error log terms (coded using SIGMA in $ERROR) - returns est.+CV%
 #
 # paramKey = tribble(
 #   ~name, ~abb, ~desc, ~panel, ~trans,

--- a/man/param_key.Rd
+++ b/man/param_key.Rd
@@ -35,6 +35,7 @@ Current options include:
 \item "logitOmSD"  - for omegas using logit transform - returns estimate & SD (calculated with logitnorm package); this option requires you provide the associated THETA separated with a "~"; e.g. "logitOmSD ~ THETA3"
 \item "addErr"     - for additive error terms (coded using SIGMA in $ERROR) - returns est.+ SD
 \item "propErr"    - for proportional error terms (coded using SIGMA in $ERROR) - returns est.+CV\%
+\item "addErrLogDV" - for additive error log terms (coded using SIGMA in $ERROR) - returns est.+CV\%
 }
 }
 \section{YAML Example}{

--- a/tests/testthat/test-format_boot_table.R
+++ b/tests/testthat/test-format_boot_table.R
@@ -10,7 +10,7 @@ test_that("format_boot_table expected dataframe: col names", {
   expect_equal(names(newDF3),  c("abb", "desc", "boot_value", "boot_ci"))
 
   #all cols
-  expect_equal(length(names(newDF5)),  24)
+  expect_equal(length(names(newDF5)),  25)
 })
 
 

--- a/tests/testthat/test-format_boot_table.R
+++ b/tests/testthat/test-format_boot_table.R
@@ -10,7 +10,7 @@ test_that("format_boot_table expected dataframe: col names", {
   expect_equal(names(newDF3),  c("abb", "desc", "boot_value", "boot_ci"))
 
   #all cols
-  expect_equal(length(names(newDF5)),  25)
+  expect_equal(length(names(newDF5)),  26)
 })
 
 

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -67,7 +67,7 @@ test_that("format_param_table continuous columns expected ouput: CI back transfo
 
   newDF5 <- newDF4%>% format_param_table()
 
-  expected_cv =  pmtables::sig(sqrt(newDF4$value[newDF4$addErrLogDV == TRUE]) * 100)
+  expected_cv =  pmtables::sig(sqrt(exp(newDF4$value[newDF4$addErrLogDV == TRUE]) -1)* 100)
   expected_value = paste0(pmtables::sig(newDF4$value[newDF4$addErrLogDV == TRUE]), " [CV\\%=", expected_cv, "]")
 
   expect_equal(newDF5$value[newDF5$abb == "Lognormal residual error"], expected_value)

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -16,7 +16,7 @@ test_that("format_param_table expected dataframe: col names", {
   expect_equal(names(newDF3),  c("type", "abb", "greek", "desc", "value", "ci", "shrinkage"))
 
   #all cols., no prse
-  expect_equal(length(names(newDF5)),  39)
+  expect_equal(length(names(newDF5)),  40)
 
 })
 

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -66,7 +66,7 @@ test_that("format_param_table continuous columns expected ouput: CI back transfo
 
   newDF5 <- newDF4%>% format_param_table()
 
-  expected_cv =  pmtables::sig(sqrt(exp(newDF4$value[newDF4$addErrLogDV == TRUE]) - 1) * 100)
+  expected_cv =  pmtables::sig(sqrt(newDF4$value[newDF4$addErrLogDV == TRUE]) * 100)
   expected_value = paste0(pmtables::sig(newDF4$value[newDF4$addErrLogDV == TRUE]), " [CV\\%=", expected_cv, "]")
 
   expect_equal(newDF5$value[newDF5$abb == "Lognormal residual error"], expected_value)

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -15,7 +15,7 @@ test_that("format_param_table expected dataframe: col names", {
   expect_equal(names(newDF3),  c("type", "abb", "greek", "desc", "value", "ci", "shrinkage"))
 
   #all cols., no prse
-  expect_equal(length(names(newDF5)),  40)
+  expect_equal(length(names(newDF5)),  41)
 })
 
 test_that("format_param_table expected dataframe: prse col", {
@@ -69,6 +69,7 @@ test_that("format_param_table continuous columns expected ouput: CI back transfo
   expected_value = paste0(pmtables::sig(newDF4$value[newDF4$addErrLogDV == TRUE]), " [CV\\%=", expected_cv, "]")
 
   expect_equal(newDF5$value[newDF5$abb == "Lognormal residual error"], expected_value)
+})
 
 test_that("format_param_table continuous columns expected ouput: greek", {
   expect_equal(newDF5$greek[newDF5$S & !newDF5$THETAERR], "$\\Sigma_{(1,1)}$")

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -16,7 +16,7 @@ test_that("format_param_table expected dataframe: col names", {
   expect_equal(names(newDF3),  c("type", "abb", "greek", "desc", "value", "ci", "shrinkage"))
 
   #all cols., no prse
-  expect_equal(length(names(newDF5)),  39) #check this
+  expect_equal(length(names(newDF5)),  40)
 })
 
 test_that("format_param_table expected dataframe: prse col", {


### PR DESCRIPTION
This PR does the following:

Adds additive error log terms (`addErrLogDV`) as  a transformation option in parameter key.

- coded using SIGMA in $ERROR
- returns est.+CV%

Example of how to use this in the parameter key:
```
SIGMA11
  abb: "Lognormal residual error"
  desc: "Variance"
  panel: RV
  trans: addErrLogDV
