### PR TITLE
THETA error block capability

### DIFF
--- a/R/defineRows.R
+++ b/R/defineRows.R
@@ -21,9 +21,10 @@ defineRows <- function(.df){
   }
   .df %>%
     dplyr::mutate(
-      TH = stringr::str_detect(name, "^TH"),
+      THETAERR = stringr::str_detect(name, "^TH") & stringr::str_detect(panel, "RV"),
+      TH = stringr::str_detect(name, "^TH") & !THETAERR,
       OM = stringr::str_detect(name, "^OM"),
-      S = stringr::str_detect(name, "^S"),
+      S = stringr::str_detect(name, "^S") |  THETAERR,
       LOG = (trans=="logTrans"),
       LOGIT = (trans=="logitTrans"),
       lognormO = (trans=="lognormalOm"),

--- a/R/define_boot_table.R
+++ b/R/define_boot_table.R
@@ -73,7 +73,7 @@ define_boot_table <- function(.boot_estimates, .nonboot_estimates, .key){
 #clean up boot
 .bootParam = .boot %>%
     bbr::param_estimates_compare() %>%
-    dplyr::rename(estimate = "50%", lower = "2.5%", upper = "97.5%") %>%
+    dplyr::rename(estimate = "p50", lower = "p2.5", upper = "p97.5") %>%
     dplyr::mutate(name = gsub("[[:punct:]]", "", parameter_names)) %>%
     dplyr::inner_join(.key, by = "name")
 

--- a/R/define_param_table.R
+++ b/R/define_param_table.R
@@ -56,7 +56,7 @@ define_param_table <- function(.estimates, .key, .ci = 95, .zscore = NULL){
     getCI(.ci = .ci, .zscore = .zscore)
 
   if(any(mod_estimates$THETAERR)){
-    message("THETA error block detected:  ", mod_estimates$parameter_names[mod_estimates$THETAERR])
+    message("THETA term was used in $ERROR:  ", mod_estimates$parameter_names[mod_estimates$THETAERR])
   }
 
   return(mod_estimates)

--- a/R/define_param_table.R
+++ b/R/define_param_table.R
@@ -57,7 +57,7 @@ define_param_table <- function(.estimates, .key, .ci = 95, .zscore = NULL){
     dplyr::arrange(as.numeric(nrow))
 
   if(any(mod_estimates$THETAERR)){
-    message("THETA term was used in $ERROR:  ", mod_estimates$parameter_names[mod_estimates$THETAERR])
+    message("THETA term was used in $ERROR:  ", paste(mod_estimates$parameter_names[mod_estimates$THETAERR]))
   }
 
   return(mod_estimates)

--- a/R/define_param_table.R
+++ b/R/define_param_table.R
@@ -57,7 +57,7 @@ define_param_table <- function(.estimates, .key, .ci = 95, .zscore = NULL){
     dplyr::arrange(as.numeric(nrow))
 
   if(any(mod_estimates$THETAERR)){
-    message("THETA term was used in $ERROR:  ", paste(mod_estimates$parameter_names[mod_estimates$THETAERR]))
+    message("THETA term was used in $ERROR:  ", paste(mod_estimates$parameter_names[mod_estimates$THETAERR], collapse = ", "))
   }
 
   return(mod_estimates)

--- a/R/define_param_table.R
+++ b/R/define_param_table.R
@@ -55,5 +55,9 @@ define_param_table <- function(.estimates, .key, .ci = 95, .zscore = NULL){
     getValueSE() %>%
     getCI(.ci = .ci, .zscore = .zscore)
 
+  if(any(mod_estimates$THETAERR)){
+    message("THETA error block detected:  ", mod_estimates$parameter_names[mod_estimates$THETAERR])
+  }
+
   return(mod_estimates)
 }

--- a/R/formatGreekNames.R
+++ b/R/formatGreekNames.R
@@ -23,7 +23,7 @@ formatGreekNames <- function(.df){
     dplyr::mutate(
       text = dplyr::case_when(
         OM ~ "Omega",
-        S ~ "Sigma",
+        S & !THETAERR ~ "Sigma",
         TRUE ~ tolower(text)),
       greek = dplyr::case_when(
         TH & LOG ~ expGreek(text, num2),

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -55,3 +55,8 @@ formatnonbootDF <- nonbootDF %>% pmparams::format_param_table()
 
 
 bootParam <-  left_join(formatnonbootDF, formatBootDF, by = c("abb", "desc"))
+
+#testing theta error block
+theta_err = paramEst %>% as.data.frame() %>% mutate(parameter_names = if_else(parameter_names == "SIGMA(1,1)", "THETA(1,1)", parameter_names))
+theta_err_key = paramKey %>% mutate(name = if_else(name == "SIGMA11", "THETA11", name))
+theta_err_df1 <- define_param_table(.estimates = theta_err, .key = theta_err_key, .ci = 95, .zscore = NULL)

--- a/tests/testthat/test-defineRows.R
+++ b/tests/testthat/test-defineRows.R
@@ -22,4 +22,10 @@ test_that("defineRows expected output: generates logical columns to indicate nam
   expect_equal(all(newDF$S[newDF$name == "THETA1"]), FALSE)
 })
 
+test_that("defineRows expected output: theta error block", {
+  expect_equal(unique(theta_err_df1$THETAERR[theta_err_df1$TH == TRUE]), FALSE)
+  expect_equal(theta_err_df1$S[theta_err_df1$THETAERR == TRUE], TRUE)
+  expect_equal(theta_err_df1$S[theta_err_df1$panel == "RV"], TRUE)
+})
+
 

--- a/tests/testthat/test-define_param_table.R
+++ b/tests/testthat/test-define_param_table.R
@@ -92,4 +92,8 @@ test_that("define_param_table generates the confidence intervals for various inp
   expect_equal(newDF_ci95$upper[7], 0.108133732)
 })
 
+test_that("define_param_table message if using theta error block", {
+  expect_message(define_param_table(.estimates = theta_err, .key = theta_err_key, .ci = 95, .zscore = NULL))
+})
+
 

--- a/tests/testthat/test-define_param_table.R
+++ b/tests/testthat/test-define_param_table.R
@@ -1,108 +1,103 @@
+withr::with_options(list(bbr.bbi_exe_path = bbr::read_bbi_path()), {
 
-test_that("define_param_table expected output: creates new parameter names without parentheses", {
-  expect_equal(newDF$name[newDF$parameter_names == "OMEGA(1,1)"], "OMEGA11")
+  test_that("define_param_table expected output: creates new parameter names without parentheses", {
+    expect_equal(newDF$name[newDF$parameter_names == "OMEGA(1,1)"], "OMEGA11")
+  })
+
+  test_that("define_param_table expected output: generates logical columns to indicate parameter type", {
+    expect_equal(newDF$TH[newDF$parameter_names == "THETA1"], TRUE)
+    expect_equal(newDF$OM[newDF$parameter_names == "THETA1"], FALSE)
+    expect_equal(newDF$OM[newDF$parameter_names == "OMEGA(1,1)"], TRUE)
+    expect_equal(newDF$S[newDF$parameter_names == "SIGMA(1,1)"], TRUE)
+    expect_equal(newDF$S[newDF$parameter_names == "THETA1"], FALSE)
+  })
+
+  test_that("define_param_table expected output:  generates logical columns for transformation", {
+    expect_true(newDF$trans[newDF$name == "THETA1"] == "logTrans" &
+                  newDF$LOG[newDF$name == "THETA1"] == TRUE &
+                  newDF$LOGIT[newDF$name == "THETA1"] == FALSE)
+
+    expect_true(newDF$trans[newDF$name == "OMEGA11"] == "lognormalOm" &
+                  newDF$LOG[newDF$name == "OMEGA11"] == FALSE &
+                  newDF$lognormO[newDF$name == "OMEGA11"] == TRUE)
+
+    expect_true(newDF$trans[newDF$name == "SIGMA11"] == "propErr" &
+                  newDF$LOG[newDF$name == "SIGMA11"] == FALSE &
+                  newDF$propErr[newDF$name == "SIGMA11"] == TRUE)
+  })
+
+  test_that("define_param_table incorrect input type: no parameter_names column",{
+    paramEst2 <- paramEst
+    colnames(paramEst2)[colnames(paramEst2) == "parameter_names"] ="no_name"
+    expect_error(capture.output(define_param_table(paramEst2, paramKey)))
+  })
+
+  test_that("define_param_table incorrect input type: missing column(s)",{
+    paramKey2 <- as.data.frame(paramKey)
+    colnames(paramKey2)[colnames(paramKey2) == "panel"] ="no_name"
+    expect_error(capture.output(define_param_table(paramEst, paramKey2)))
+  })
+
+  test_that("define_param_table handles multiple estimate input types", {
+    pathDF <- define_param_table(paramPath, paramKey)
+    expect_equal(pathDF$estimate[pathDF$name == "OMEGA22"], 0.0826922)
+
+    mod_est <- bbr::read_model(system.file("model/nonmem/102", package = "pmparams"))
+    pathDF2 <- define_param_table(mod_est, paramKey)
+    expect_equal(pathDF2$estimate[pathDF2$name == "OMEGA22"], 0.0826922)
+
+    pathDF3 <- define_param_table(paramModel, paramKey)
+    expect_equal(pathDF3$estimate[pathDF3$name == "OMEGA22"], 0.0826922)
+
+    pathDF4 <- define_param_table(paramModel %>% bbr::model_summary(), paramKey)
+    expect_equal(pathDF4$estimate[pathDF4$name == "OMEGA22"], 0.0826922)
+
+  })
+
+  test_that("define_param_table handles multiple parameter key input types", {
+    pathDF <- define_param_table(paramPath, system.file("model/nonmem/pk-parameter-key-new.yaml", package = "pmparams"))
+    expect_equal(pathDF$estimate[pathDF$name == "OMEGA22"], 0.0826922)
+  })
+
+  test_that("define_param_table handles multiple parameter key input types", {
+    key_file <- system.file("model/nonmem/pk-parameter-key.yaml", package = "pmparams")
+    key_df <- pmtables::yaml_as_df(key_file)
+    pathDF <- define_param_table(paramPath, key_df)
+    expect_equal(pathDF$estimate[pathDF$name == "OMEGA22"], 0.0826922)
+  })
+
+  test_that("define_param_table incorrect parameter key input type: Only abb, desc, panel and trans arguments will be used, all others ignored", {
+    expect_warning(capture.output(define_param_table(paramPath, system.file("model/nonmem/pk-parameter-key-both.yaml", package = "pmparams"))))
+  })
+
+  test_that("define_param_table generates correct corr_SD", {
+    expect_true(all(newDF$estimate == newDF$value))
+    expect_true(all(newDF$stderr == newDF$se))
+    expect_true(newDF$corr_SD[9] == "0.511")
+    expect_true(newDF$corr_SD[1] == "-")
+    expect_true(newDF$corr_SD[6] == "-")
+  })
+
+  test_that("define_param_table generates the confidence intervals for various inputs", {
+    newDF_ci95 <- define_param_table(.estimates = paramEst, .key = paramKey, .ci = 95, .zscore = NULL)
+    newDF_ci90 <- define_param_table(.estimates = paramEst, .key = paramKey, .ci = 90, .zscore = NULL)
+
+    expect_equal(newDF_ci90$lower[1], 0.33047798)
+    expect_equal(newDF_ci90$upper[2], 4.1640688)
+
+    expect_equal(newDF_ci95$lower[4], 4.1721829)
+    expect_equal(newDF_ci95$upper[7], 0.10195012)
+  })
+
+  test_that("define_param_table expected dataframe: respects yaml key order",{
+    paramKey2 <- paramKey %>%
+      filter(name %in% newDF$name)
+
+    expect_equal(newDF$name, paramKey2$name)
+  })
+
+  test_that("define_param_table message if using theta error block", {
+    expect_message(define_param_table(.estimates = theta_err, .key = theta_err_key, .ci = 95, .zscore = NULL))
+  })
+
 })
-
-test_that("define_param_table expected output: generates logical columns to indicate parameter type", {
-  expect_equal(newDF$TH[newDF$parameter_names == "THETA1"], TRUE)
-  expect_equal(newDF$OM[newDF$parameter_names == "THETA1"], FALSE)
-  expect_equal(newDF$OM[newDF$parameter_names == "OMEGA(1,1)"], TRUE)
-  expect_equal(newDF$S[newDF$parameter_names == "SIGMA(1,1)"], TRUE)
-  expect_equal(newDF$S[newDF$parameter_names == "THETA1"], FALSE)
-})
-
-test_that("define_param_table expected output:  generates logical columns for transformation", {
-  expect_true(newDF$trans[newDF$name == "THETA1"] == "logTrans" &
-                newDF$LOG[newDF$name == "THETA1"] == TRUE &
-                newDF$LOGIT[newDF$name == "THETA1"] == FALSE)
-
-  expect_true(newDF$trans[newDF$name == "OMEGA11"] == "lognormalOm" &
-                newDF$LOG[newDF$name == "OMEGA11"] == FALSE &
-                newDF$lognormO[newDF$name == "OMEGA11"] == TRUE)
-
-  expect_true(newDF$trans[newDF$name == "SIGMA11"] == "propErr" &
-                newDF$LOG[newDF$name == "SIGMA11"] == FALSE &
-                newDF$propErr[newDF$name == "SIGMA11"] == TRUE)
-})
-
-test_that("define_param_table incorrect input type: no parameter_names column",{
-  paramEst2 <- paramEst
-  colnames(paramEst2)[colnames(paramEst2) == "parameter_names"] ="no_name"
-  expect_error(capture.output(define_param_table(paramEst2, paramKey)))
-})
-
-test_that("define_param_table incorrect input type: missing column(s)",{
-  paramKey2 <- as.data.frame(paramKey)
-  colnames(paramKey2)[colnames(paramKey2) == "panel"] ="no_name"
-  expect_error(capture.output(define_param_table(paramEst, paramKey2)))
-})
-
-test_that("define_param_table handles multiple estimate input types", {
-  skip_if_no_bbi("MPT-DPT-003")
-  pathDF <- define_param_table(paramPath, paramKey)
-  expect_equal(pathDF$estimate[pathDF$name == "OMEGA22"], 0.0826922)
-
-  mod_est <- bbr::read_model(system.file("model/nonmem/102", package = "pmparams"))
-  pathDF2 <- define_param_table(mod_est, paramKey)
-  expect_equal(pathDF2$estimate[pathDF2$name == "OMEGA22"], 0.0826922)
-
-  pathDF3 <- define_param_table(paramModel, paramKey)
-  expect_equal(pathDF3$estimate[pathDF3$name == "OMEGA22"], 0.0826922)
-
-  pathDF4 <- define_param_table(paramModel %>% bbr::model_summary(), paramKey)
-  expect_equal(pathDF4$estimate[pathDF4$name == "OMEGA22"], 0.0826922)
-
-})
-
-test_that("define_param_table handles multiple parameter key input types", {
-  skip_if_no_bbi("MPT-DPT-004")
-  pathDF <- define_param_table(paramPath, system.file("model/nonmem/pk-parameter-key-new.yaml", package = "pmparams"))
-  expect_equal(pathDF$estimate[pathDF$name == "OMEGA22"], 0.0826922)
-})
-
-test_that("define_param_table handles multiple parameter key input types", {
-  skip_if_no_bbi("MPT-DPT-004")
-  key_file <- system.file("model/nonmem/pk-parameter-key.yaml", package = "pmparams")
-  key_df <- pmtables::yaml_as_df(key_file)
-  pathDF <- define_param_table(paramPath, key_df)
-  expect_equal(pathDF$estimate[pathDF$name == "OMEGA22"], 0.0826922)
-})
-
-test_that("define_param_table incorrect parameter key input type: Only abb, desc, panel and trans arguments will be used, all others ignored", {
-  skip_if_no_bbi("MPT-DPT-005")
-  expect_warning(capture.output(define_param_table(paramPath, system.file("model/nonmem/pk-parameter-key-both.yaml", package = "pmparams"))))
-})
-
-test_that("define_param_table generates correct corr_SD", {
-  expect_true(all(newDF$estimate == newDF$value))
-  expect_true(all(newDF$stderr == newDF$se))
-  expect_true(newDF$corr_SD[9] == "0.511")
-  expect_true(newDF$corr_SD[1] == "-")
-  expect_true(newDF$corr_SD[6] == "-")
-})
-
-test_that("define_param_table generates the confidence intervals for various inputs", {
-  newDF_ci95 <- define_param_table(.estimates = paramEst, .key = paramKey, .ci = 95, .zscore = NULL)
-  newDF_ci90 <- define_param_table(.estimates = paramEst, .key = paramKey, .ci = 90, .zscore = NULL)
-
-  expect_equal(newDF_ci90$lower[1], 0.33047798)
-  expect_equal(newDF_ci90$upper[2], 4.1640688)
-
-  expect_equal(newDF_ci95$lower[4], 4.1721829)
-  expect_equal(newDF_ci95$upper[7], 0.10195012)
-})
-
-
-test_that("define_param_table message if using theta error block", {
-  expect_message(define_param_table(.estimates = theta_err, .key = theta_err_key, .ci = 95, .zscore = NULL))
-})
-
-
-test_that("define_param_table expected dataframe: respects yaml key order",{
-  paramKey2 <- paramKey %>%
-    filter(name %in% newDF$name)
-
-  expect_equal(newDF$name, paramKey2$name)
-})
-
-

--- a/tests/testthat/test-format_boot_table.R
+++ b/tests/testthat/test-format_boot_table.R
@@ -10,7 +10,7 @@ test_that("format_boot_table expected dataframe: col names", {
   expect_equal(names(newDF3),  c("abb", "desc", "boot_value", "boot_ci"))
 
   #all cols
-  expect_equal(length(names(newDF5)),  24)
+  expect_equal(length(names(newDF5)),  25)
 })
 
 

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -15,7 +15,7 @@ test_that("format_param_table expected dataframe: col names", {
   expect_equal(names(newDF3),  c("type", "abb", "greek", "desc", "value", "ci", "shrinkage"))
 
   #all cols., no prse
-  expect_equal(length(names(newDF5)),  39)
+  expect_equal(length(names(newDF5)),  40)
 })
 
 test_that("format_param_table expected dataframe: prse col", {

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -7,16 +7,15 @@ newDF4 <- newDF %>%
 newDF5 <- newDF %>%
   format_param_table(.select_cols = "all")
 
-newDF6 <- newDF %>%
-  format_param_table(.select_cols = "all", .prse = TRUE)
-
+newDF6 <- theta_err_df1 %>%
+  format_param_table(.select_cols = "all")
 
 test_that("format_param_table expected dataframe: col names", {
   #default cols., no prse
   expect_equal(names(newDF3),  c("type", "abb", "greek", "desc", "value", "ci", "shrinkage"))
 
   #all cols., no prse
-  expect_equal(length(names(newDF5)),  39) #check this
+  expect_equal(length(names(newDF5)),  40)
 })
 
 test_that("format_param_table expected dataframe: prse col", {
@@ -54,5 +53,10 @@ test_that("format_param_table continuous columns expected ouput: shrinkage", {
 test_that("format_param_table continuous columns expected ouput: value", {
   expect_equal(newDF3$value[1], "1.54")
   expect_equal(newDF3$value[6], "0.221 [CV\\%=49.7]")
+})
+
+test_that("format_param_table continuous columns expected ouput: greek", {
+  expect_equal(newDF5$greek[newDF5$S & !newDF5$THETAERR], "$\\Sigma_{(1,1)}$")
+  expect_equal(newDF6$greek[newDF6$S & newDF6$THETAERR], "$\\theta_{(1,1)}$")
 })
 


### PR DESCRIPTION
Allow users to input THETA in $ERROR block. `pmparams` will treat the THETA as a SIGMA in $ERROR block for calculations. The name "theta" will still be present in final table.

Example of how to use this in the parameter key (panel must be `RV`):
```
THETA11:
  abb: "Proportional"
  desc: "Variance"
  panel: RV
  trans: propErr

