### PR TITLE
make getPanelName less strict

### DIFF
--- a/R/getPanelName.R
+++ b/R/getPanelName.R
@@ -17,15 +17,15 @@ getPanelName = function(.df){
     dplyr::mutate(
       type = dplyr::case_when(panel=="RV" ~ "Residual variance",
                               OM & !diag ~ "Interindividual covariance parameters",
-                              OM & diag & panel=="IIV" ~ "Interindividual variance parameters",
-                              OM & diag & panel=="IOV"  ~ "Interoccasion variance parameters",
+                              panel=="IIV" ~ "Interindividual variance parameters",
+                              panel=="IOV"  ~ "Interoccasion variance parameters",
                               panel=="cov" ~ "Covariate effect parameters",
                               panel=="struct" ~ "Structural model parameters"),
 
       type_f = dplyr::case_when(panel=="RV" ~ 6,
                          OM & !diag ~ 5,
-                         OM & diag & panel=="IIV" ~ 3,
-                         OM & diag & panel=="IOV"  ~ 4,
+                         panel=="IIV" ~ 3,
+                         panel=="IOV"  ~ 4,
                          panel=="cov" ~ 2,
                          panel=="struct" ~ 1)
     ) %>%

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -80,3 +80,18 @@ test_that("format_param_table expected dataframe: respects yaml key order", {
   expect_equal(unname(unlist(param_yaml))[grepl('desc',names(unlist(param_yaml)),fixed=T) & unlist(param_yaml) %in% newDF3$desc],
                newDF3$desc)
 })
+
+test_that("format_param_table panel expected ouput", {
+  paramKey1 <- paramKey %>%
+    mutate(
+      panel = if_else(name == "THETA2", "IIV", panel),
+      trans = if_else(name == "THETA2", "none", trans)
+    )
+
+  newDF7 <- define_param_table(.estimates = paramEst, .key = paramKey1, .ci = 95, .zscore = NULL)
+  newDF8 <- format_param_table(newDF7, .select_cols = "all")
+
+  expect_equal(newDF8$type[newDF8$name == "THETA2"], "Interindividual variance parameters")
+  expect_equal(newDF8$type_f[newDF8$name == "THETA2"], 3)
+  expect_equal(newDF8$panel[newDF8$name == "THETA2"], "IIV")
+})


### PR DESCRIPTION
Allow user more control over paneling parameters- remove OM & diag requirements for IIV and IOV panels 