### PR TITLE
Update wording

### DIFF
--- a/R/format_param_table.R
+++ b/R/format_param_table.R
@@ -21,8 +21,8 @@
 #' @param .df parameter estimates output from \code{\link[pmparams]{define_param_table}} with modifications ready for formatting
 #' @param .select_cols columns to select for output. Default selects "type", "abb", "greek", "desc", "value", "ci", "shrinkage". To return all columns, specify "all" for .select_cols
 #' @param .prse output pRSE. Default is FALSE
-#' @param .digit set significant digits for output (optional). Default is three digits
-#' @param .maxex set maxex for computation (optional). Default is NULL
+#' @param .digit number of significant digits. Default is three digits
+#' @param .maxex maximum number of significant digits before moving to scientific notation. Default is NULL
 #'
 #' @examples
 #'

--- a/R/param-key.R
+++ b/R/param-key.R
@@ -31,7 +31,7 @@
 #'   - "logitOmSD"  - for omegas using logit transform - returns estimate & SD (calculated with logitnorm package); this option requires you provide the associated THETA separated with a "~"; e.g. "logitOmSD ~ THETA3"
 #'   - "addErr"     - for additive error terms (coded using SIGMA in $ERROR) - returns est.+ SD
 #'   - "propErr"    - for proportional error terms (coded using SIGMA in $ERROR) - returns est.+CV%
-#'   - "addErrLogDV" - for additive error log terms (coded using SIGMA in $ERROR) - returns est.+CV%
+#'   - "addErrLogDV" - for additive error when DV modeled in log domain (still coded using SIGMA in $ERROR) - returns est.+CV%
 #'
 #' # YAML Example
 #'

--- a/inst/model/nonmem/pk-parameter-key-both.yaml
+++ b/inst/model/nonmem/pk-parameter-key-both.yaml
@@ -28,7 +28,7 @@
 ##'                     - e.g. "logitOmSD ~ THETA3"
 ##'        "addErr"     - for additive error terms (coded using SIGMA in $ERROR) - returns est.+ SD
 ##'        "propErr"    - for proportional error terms (coded using SIGMA in $ERROR) - returns est.+CV%
-##'        "addErrLogDV" - for additive error log terms (coded using SIGMA in $ERROR) - returns est.+CV%
+##'        "addErrLogDV" - for additive error when DV modeled in log domain (still coded using SIGMA in $ERROR) - returns est.+CV%
 #
 # paramKey = tribble(
 #   ~name, ~abb, ~desc, ~panel, ~trans,

--- a/inst/model/nonmem/pk-parameter-key-new.yaml
+++ b/inst/model/nonmem/pk-parameter-key-new.yaml
@@ -28,7 +28,7 @@
 ##'                     - e.g. "logitOmSD ~ THETA3"
 ##'        "addErr"     - for additive error terms (coded using SIGMA in $ERROR) - returns est.+ SD
 ##'        "propErr"    - for proportional error terms (coded using SIGMA in $ERROR) - returns est.+CV%
-##'        "addErrLogDV" - for additive error log terms (coded using SIGMA in $ERROR) - returns est.+CV%
+##'        "addErrLogDV" - for additive error when DV modeled in log domain (still coded using SIGMA in $ERROR) - returns est.+CV%
 #
 # paramKey = tribble(
 #   ~name, ~abb, ~desc, ~panel, ~trans,

--- a/inst/model/nonmem/pk-parameter-key.yaml
+++ b/inst/model/nonmem/pk-parameter-key.yaml
@@ -28,7 +28,7 @@
 ##'                     - e.g. "logitOmSD ~ THETA3"
 ##'        "addErr"     - for additive error terms (coded using SIGMA in $ERROR) - returns est.+ SD
 ##'        "propErr"    - for proportional error terms (coded using SIGMA in $ERROR) - returns est.+CV%
-##'        "addErrLogDV" - for additive error log terms (coded using SIGMA in $ERROR) - returns est.+CV%
+##'        "addErrLogDV" - for additive error when DV modeled in log domain (still coded using SIGMA in $ERROR) - returns est.+CV%
 #
 # paramKey = tribble(
 #   ~name, ~abb, ~desc, ~panel, ~trans,

--- a/man/format_param_table.Rd
+++ b/man/format_param_table.Rd
@@ -19,9 +19,9 @@ format_param_table(
 
 \item{.prse}{output pRSE. Default is FALSE}
 
-\item{.digit}{set significant digits for output (optional). Default is three digits}
+\item{.digit}{number of significant digits. Default is three digits}
 
-\item{.maxex}{set maxex for computation (optional). Default is NULL}
+\item{.maxex}{maximum number of significant digits before moving to scientific notation. Default is NULL}
 }
 \description{
 Format parameter estimate values and output selected columns to be shown in

--- a/man/param_key.Rd
+++ b/man/param_key.Rd
@@ -35,7 +35,7 @@ Current options include:
 \item "logitOmSD"  - for omegas using logit transform - returns estimate & SD (calculated with logitnorm package); this option requires you provide the associated THETA separated with a "~"; e.g. "logitOmSD ~ THETA3"
 \item "addErr"     - for additive error terms (coded using SIGMA in $ERROR) - returns est.+ SD
 \item "propErr"    - for proportional error terms (coded using SIGMA in $ERROR) - returns est.+CV\%
-\item "addErrLogDV" - for additive error log terms (coded using SIGMA in $ERROR) - returns est.+CV\%
+\item "addErrLogDV" - for additive error when DV modeled in log domain (still coded using SIGMA in $ERROR) - returns est.+CV\%
 }
 }
 \section{YAML Example}{


### PR DESCRIPTION
Parameter key notes:
- clearer language for `addErrLogDV`

`format_param_table` argument descriptions:
- Make match argument descriptions in [`pmtables::sig` ](https://github.com/metrumresearchgroup/pmtables/blob/267f67aad0bcdd061ebf2c9dc55f624b586e4e75/R/utils.R#L26-L27)
- `.digit`
- `.maxex`

Closes: https://github.com/metrumresearchgroup/pmparams/issues/65, https://github.com/metrumresearchgroup/pmparams/issues/68
