### PR TITLE
Remove upper constraint on glue package.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     pmtables,
     rlang,
     stringr,
-    glue (< 1.8.0),
+    glue,
     logitnorm,
     purrr,
     tibble,


### PR DESCRIPTION
This was never _totally_ necessary due to MPN and using CI to control the glue version, but was done to indicate that the previous release would be incompatible with glue 1.8.0; mostly due to the interaction with pmtables

closes https://github.com/metrumresearchgroup/pmparams/issues/79