### PR TITLE
Adjust boot notes

### DIFF
--- a/R/param-notes.R
+++ b/R/param-notes.R
@@ -119,7 +119,7 @@ boot_notes <- function(.ci, .n_run){
 
   list(
     boot_ci = paste0(
-      "The confidence interval was determined from the ", lower, "th and ",
+      "The CI was determined from the ", lower, "th and ",
       upper, "th percentiles of the non-parametric bootstrap (n=", .n_run, ") estimates."
     )
   )

--- a/R/param-notes.R
+++ b/R/param-notes.R
@@ -105,17 +105,27 @@ param_notes <- function(.ci = 95, .zscore = NULL){
 #' }
 #' @seealso [param_notes()]
 #' @export
-boot_notes <- function(.ci, .n_run){
-  if(!checkmate::test_integerish(.ci, lower = 1, upper = 99, len = 1)){
-    rlang::abort("`.ci` must be between 1 and 99")
+boot_notes <- function(.ci = NULL, .n_run = NULL){
+  if(is.null(.ci)){
+    lower <- "x"; upper <- "y"
+    rlang::warn(".ci was not provided, so a a placeholder will be used.")
+  }else{
+    if(!checkmate::test_integerish(.ci, lower = 1, upper = 99, len = 1)){
+      rlang::abort("`.ci` must be between 1 and 99")
+    }
+    lower <- (100 - .ci) / 2
+    upper <- 100 - lower
   }
 
-  if(!checkmate::test_integerish(.n_run, lower = 1, len = 1)){
-    rlang::abort("`.n_run` must be an integer greater than 1.")
+  if(is.null(.n_run)){
+    .n_run <- "xx"
+    rlang::warn(".n_run was not provided, so a a placeholder will be used.")
+  }else{
+    if(!checkmate::test_integerish(.n_run, lower = 1, len = 1)){
+      rlang::abort("`.n_run` must be an integer greater than 1.")
+    }
   }
 
-  lower <- (100 - .ci) / 2
-  upper <- 100 - lower
 
   list(
     boot_ci = paste0(

--- a/man/boot_notes.Rd
+++ b/man/boot_notes.Rd
@@ -4,7 +4,7 @@
 \alias{boot_notes}
 \title{Generate footnotes for a bootstrap table}
 \usage{
-boot_notes(.ci, .n_run)
+boot_notes(.ci = NULL, .n_run = NULL)
 }
 \arguments{
 \item{.ci}{Confidence interval. A value from 1 to 99 denoting the percent


### PR DESCRIPTION
 - Update `boot_notes()` to say "The CI was determined..." Instead of "The confidence interval was determined..."
 - Update `boot_notes()` to work with no args supplied
    - If arguments are `NULL`, create notes with 'xx' for the missing info, and display a warning that you need to supply the `.ci` and `.nrun` to have appropriately formatted notes