### PR TITLE
Adjust zscore in latex

### DIFF
--- a/R/param-notes.R
+++ b/R/param-notes.R
@@ -51,7 +51,7 @@ param_notes <- function(.ci = 95, .zscore = NULL){
     rse = "RSE: relative standard error",
     se   = "SE: standard error",
     sd   = "SD: standard deviation",
-    ciEq =  paste0("CI = estimate $\\pm$ $\\mathcal{Z}_{\\alpha/2}$ $\\cdot$ SE, $\\alpha = ", alpha, "$"),
+    ciEq =  paste0("CI = estimate $\\pm$ $z_{\\alpha/2}$ $\\cdot$ SE, $\\alpha = ", alpha, "$"),
     cvOmegaEq = "CV\\% of log-normal omega = sqrt(exp(estimate) - 1) $\\cdot$ 100",
     cvSigmaEq = "CV\\% of sigma = sqrt(estimate) $\\cdot$ 100",
     logTrans = "Parameters estimated in the log domain were back-transformed for clarity",

--- a/tests/testthat/test-param-notes.R
+++ b/tests/testthat/test-param-notes.R
@@ -5,14 +5,14 @@ test_that("param_notes expected output: alpha",{
   alpha <- 0.05
   expect_equal(
     eq2$ciEq,
-    paste0("CI = estimate $\\pm$ $\\mathcal{Z}_{\\alpha/2}$ $\\cdot$ SE, $\\alpha = ", alpha, "$")
+    paste0("CI = estimate $\\pm$ $z_{\\alpha/2}$ $\\cdot$ SE, $\\alpha = ", alpha, "$")
   )
 
   alpha <- 0.5
   eq3 <- param_notes(.ci = 50)
   expect_equal(
     eq3$ciEq,
-    paste0("CI = estimate $\\pm$ $\\mathcal{Z}_{\\alpha/2}$ $\\cdot$ SE, $\\alpha = ", alpha, "$")
+    paste0("CI = estimate $\\pm$ $z_{\\alpha/2}$ $\\cdot$ SE, $\\alpha = ", alpha, "$")
   )
 })
 


### PR DESCRIPTION
 - The mathcal latex package seems to have variable behavior for capital letters. The rendering looked good on my end, but not for others. To avoid varying behavior, drop the use of this package and use lowercase alpha