### PR TITLE
Add span labels to and correct column selection in make_boot_pmtable

### DIFF
--- a/R/make-boot-pmtable.R
+++ b/R/make-boot-pmtable.R
@@ -20,14 +20,19 @@
 #' If these `pmtables` settings do not work for your parameter table, you can
 #' overwrite them afterwards using desired `pmtables` commands.
 #'
-#' @param .df bootstrap parameter dataset and non-bootstrap parameter dataset combined.
-#' @param .pmtype parameter table type. Options include:
+#' @param .df Combined dataset of model and bootstrap parameter estimates. See
+#'  examples.
+#' @param .pmtype Parameter table type. Options include:
 #' - `"full"` (all rows in `.df` retained in pmtable). This is the default.
 #' - `"fixed"` (all rows with type = "Struct" or "effect"),
 #' - `"structural"` (all rows with type = "Struct"),
 #' - `"covariate"` (all rows with type = "effect"),
 #' - `"random"` (all rows with greek = "Omega" or type = "Resid").
-#' @param .width notes width. Defaults to 1.
+#' @param .span_model_label A label for the span above columns relating to the
+#'  model that was bootstrapped.
+#' @param .span_boot_label A label for the span above columns relating to the
+#'  confidence interval of bootstrap estimates.
+#' @param .width Notes width. Defaults to 1.
 #'
 #' @seealso [make_pmtable()], [boot_notes()]
 #' @examples
@@ -70,6 +75,8 @@
 make_boot_pmtable <- function(
     .df,
     .pmtype = c("full", "fixed", "structural", "covariate", "random"),
+    .span_model_label = "Full model",
+    .span_boot_label = "Non-parametric bootstrap",
     .width = 1
 ){
   checkmate::assert_numeric(.width)
@@ -118,24 +125,24 @@ make_boot_pmtable <- function(
         pmtables::st_new() %>%
         pmtables::st_panel("type") %>%
         pmtables::st_blank("abb", "greek", "desc") %>%
-        pmtables::st_span("Final model", value:shrinkage) %>%
-        pmtables::st_span("Non-parametric bootstrap", {{boot_names}})
+        pmtables::st_span(.span_model_label, value:shrinkage) %>%
+        pmtables::st_span(.span_boot_label, {{boot_names}})
     } else if (.pmtype %in% c("fixed", "structural", "covariate")){
       pm_tab0 %>%
         dplyr::select(-shrinkage) %>%
         pmtables::st_new() %>%
         pmtables::st_panel("type") %>%
         pmtables::st_blank("abb", "greek", "desc") %>%
-        pmtables::st_span("Final model", value) %>%
-        pmtables::st_span("Non-parametric bootstrap", {{boot_names}})
+        pmtables::st_span(.span_model_label, value) %>%
+        pmtables::st_span(.span_boot_label, {{boot_names}})
     } else if (.pmtype == "random"){
       pm_tab0 %>%
         dplyr::select(-desc) %>%
         pmtables::st_new() %>%
         pmtables::st_panel("type") %>%
         pmtables::st_blank("abb", "greek") %>%
-        pmtables::st_span("Final model", value:shrinkage) %>%
-        pmtables::st_span("Non-parametric bootstrap", {{boot_names}})
+        pmtables::st_span(.span_model_label, value:shrinkage) %>%
+        pmtables::st_span(.span_boot_label, {{boot_names}})
     }
 
 

--- a/R/make-boot-pmtable.R
+++ b/R/make-boot-pmtable.R
@@ -77,7 +77,7 @@
 make_boot_pmtable <- function(
     .df,
     .pmtype = c("full", "fixed", "structural", "covariate", "random"),
-    .span_model_label = "Full model",
+    .span_model_label = "Final model",
     .span_boot_label = "Non-parametric bootstrap",
     .drop_model_ci = TRUE,
     .width = 1

--- a/R/make-boot-pmtable.R
+++ b/R/make-boot-pmtable.R
@@ -89,12 +89,12 @@ make_boot_pmtable <- function(
     stop(msg)
   }
 
-  # Extract bootstrap columns
-  boot_cols_keep <- names(.df)[grepl("boot_", names(.df))]
-  .df_new <- .df %>% dplyr::select(all_of(c(req_cols, boot_cols_keep)))
+  # Remove ci_[x] columns
+  ci_cols <- names(.df)[grepl("^ci_", names(.df))]
+  .df <- .df %>% dplyr::select(-any_of(ci_cols))
 
   # Rename CI and percent columns
-  .df_new <- rename_boot_cols(.df_new)
+  .df_new <- rename_boot_cols(.df)
   boot_names <- attributes(.df_new)$renamed_cols
 
   pm_tab0 <-

--- a/R/make-boot-pmtable.R
+++ b/R/make-boot-pmtable.R
@@ -32,6 +32,8 @@
 #'  model that was bootstrapped.
 #' @param .span_boot_label A label for the span above columns relating to the
 #'  confidence interval of bootstrap estimates.
+#' @param .drop_model_ci Logical (`T/F`). If `TRUE` (the default), drop original
+#'  CI columns (`ci_[x]`).
 #' @param .width Notes width. Defaults to 1.
 #'
 #' @seealso [make_pmtable()], [boot_notes()]
@@ -47,7 +49,7 @@
 #' param_df <- define_param_table(
 #'  .estimates = mod,
 #'  .key = paramKey,
-#' ) %>% format_param_table()
+#' ) %>% format_param_table(.prse = TRUE)
 #'
 #' # Bootstrap estimates
 #' boot_run <- bbr::read_model(file.path(model_dir, "106-boot"))
@@ -63,7 +65,7 @@
 #' make_boot_pmtable(.df = combine_df, .pmtype = "fixed") %>%
 #'  pmtables::stable() %>%
 #'  # preview in Rstudio viewer (requires `magick` and `pdftools`)
-#'  pmtables::st_as_image(border = "0.8cm 0.7cm")
+#'  pmtables::st_as_image(border = "0.8cm 0.7cm 1.8cm 0.8cm")
 #'
 #'
 #' # Random effects table
@@ -77,6 +79,7 @@ make_boot_pmtable <- function(
     .pmtype = c("full", "fixed", "structural", "covariate", "random"),
     .span_model_label = "Full model",
     .span_boot_label = "Non-parametric bootstrap",
+    .drop_model_ci = TRUE,
     .width = 1
 ){
   checkmate::assert_numeric(.width)
@@ -96,27 +99,39 @@ make_boot_pmtable <- function(
     stop(msg)
   }
 
-  # Remove ci_[x] columns
+  # Remove ci_[x] columns or rename downstream
   ci_cols <- names(.df)[grepl("^ci_", names(.df))]
-  .df <- .df %>% dplyr::select(-any_of(ci_cols))
+  if(isTRUE(.drop_model_ci)){
+    .df <- .df %>% dplyr::select(-any_of(ci_cols))
+    ci_names_lst <- list()
+  }else{
+    new_ci_names <-  paste0(stringr::str_remove(ci_cols, "ci_"), "\\% CI")
+    ci_names_lst <- rlang::set_names(as.list(new_ci_names), ci_cols)
+  }
 
   # Rename CI and percent columns
   .df_new <- rename_boot_cols(.df)
   boot_names <- attributes(.df_new)$renamed_cols
 
+  # Filter and select relevant columns
   pm_tab0 <-
     if (.pmtype == "full"){
       .df_new
     } else if (.pmtype == "fixed"){
-      .df_new %>% dplyr::filter(stringr::str_detect(type, "Struct") | stringr::str_detect(type, "effect"))
+      .df_new %>% dplyr::filter(stringr::str_detect(type, "Struct") | stringr::str_detect(type, "effect")) %>%
+        dplyr::select(-shrinkage)
     } else if (.pmtype == "structural") {
-      .df_new %>% dplyr::filter(stringr::str_detect(type, "Struct"))
+      .df_new %>% dplyr::filter(stringr::str_detect(type, "Struct")) %>% dplyr::select(-shrinkage)
     } else if (.pmtype == "covariate") {
-      .df_new %>% dplyr::filter(stringr::str_detect(type, "effect"))
+      .df_new %>% dplyr::filter(stringr::str_detect(type, "effect")) %>% dplyr::select(-shrinkage)
     } else if (.pmtype == "random") {
-      .df_new %>% dplyr::filter(stringr::str_detect(greek, "Omega") | stringr::str_detect(type, "Resid"))
+      .df_new %>% dplyr::filter(stringr::str_detect(greek, "Omega") | stringr::str_detect(type, "Resid")) %>%
+        dplyr::select(-desc)
     }
 
+  # Get spanned columns for original model
+  model_names <- c("value", ci_cols, "shrinkage", "pRSE")
+  model_names <- model_names[model_names %in% names(pm_tab0)]
 
   # Create pmtable
   pm_tab1 <-
@@ -125,32 +140,34 @@ make_boot_pmtable <- function(
         pmtables::st_new() %>%
         pmtables::st_panel("type") %>%
         pmtables::st_blank("abb", "greek", "desc") %>%
-        pmtables::st_span(.span_model_label, value:shrinkage) %>%
+        pmtables::st_span(.span_model_label, {{model_names}}) %>%
         pmtables::st_span(.span_boot_label, {{boot_names}})
     } else if (.pmtype %in% c("fixed", "structural", "covariate")){
       pm_tab0 %>%
-        dplyr::select(-shrinkage) %>%
         pmtables::st_new() %>%
         pmtables::st_panel("type") %>%
         pmtables::st_blank("abb", "greek", "desc") %>%
-        pmtables::st_span(.span_model_label, value) %>%
+        pmtables::st_span(.span_model_label, {{model_names}}) %>%
         pmtables::st_span(.span_boot_label, {{boot_names}})
     } else if (.pmtype == "random"){
       pm_tab0 %>%
-        dplyr::select(-desc) %>%
         pmtables::st_new() %>%
         pmtables::st_panel("type") %>%
         pmtables::st_blank("abb", "greek") %>%
-        pmtables::st_span(.span_model_label, value:shrinkage) %>%
+        pmtables::st_span(.span_model_label, {{model_names}}) %>%
         pmtables::st_span(.span_boot_label, {{boot_names}})
     }
 
-
+  # Rename and return
   pm_tab2 <- pm_tab1 %>%
     pmtables::st_notes_detach(width = .width) %>%
-    pmtables::st_rename("Estimate" = "value",
-                        "Shrinkage (\\%)" = "shrinkage",
-                        "RSE (\\%)" = "pRSE"
+    pmtables::st_rename(
+      .list = rlang::list2(
+        "value" = "Estimate",
+        !!!ci_names_lst,
+        "shrinkage" = "Shrinkage (\\%)",
+        "pRSE" = "RSE (\\%)"
+      )
     )
 
   return(pm_tab2)
@@ -174,5 +191,6 @@ rename_boot_cols <- function(.df) {
 
   # Store renamed columns for downstream use
   attr(.df_new, "renamed_cols") <- setdiff(names(.df_new), names(.df))
+
   return(.df_new)
 }

--- a/man/make_boot_pmtable.Rd
+++ b/man/make_boot_pmtable.Rd
@@ -7,7 +7,7 @@
 make_boot_pmtable(
   .df,
   .pmtype = c("full", "fixed", "structural", "covariate", "random"),
-  .span_model_label = "Full model",
+  .span_model_label = "Final model",
   .span_boot_label = "Non-parametric bootstrap",
   .drop_model_ci = TRUE,
   .width = 1

--- a/man/make_boot_pmtable.Rd
+++ b/man/make_boot_pmtable.Rd
@@ -9,6 +9,7 @@ make_boot_pmtable(
   .pmtype = c("full", "fixed", "structural", "covariate", "random"),
   .span_model_label = "Full model",
   .span_boot_label = "Non-parametric bootstrap",
+  .drop_model_ci = TRUE,
   .width = 1
 )
 }
@@ -30,6 +31,9 @@ model that was bootstrapped.}
 
 \item{.span_boot_label}{A label for the span above columns relating to the
 confidence interval of bootstrap estimates.}
+
+\item{.drop_model_ci}{Logical (\code{T/F}). If \code{TRUE} (the default), drop original
+CI columns (\code{ci_[x]}).}
 
 \item{.width}{Notes width. Defaults to 1.}
 }
@@ -71,7 +75,7 @@ mod <- bbr::read_model(file.path(model_dir, "106"))
 param_df <- define_param_table(
  .estimates = mod,
  .key = paramKey,
-) \%>\% format_param_table()
+) \%>\% format_param_table(.prse = TRUE)
 
 # Bootstrap estimates
 boot_run <- bbr::read_model(file.path(model_dir, "106-boot"))
@@ -87,7 +91,7 @@ combine_df <- dplyr::left_join(param_df, boot_df)
 make_boot_pmtable(.df = combine_df, .pmtype = "fixed") \%>\%
  pmtables::stable() \%>\%
  # preview in Rstudio viewer (requires `magick` and `pdftools`)
- pmtables::st_as_image(border = "0.8cm 0.7cm")
+ pmtables::st_as_image(border = "0.8cm 0.7cm 1.8cm 0.8cm")
 
 
 # Random effects table

--- a/man/make_boot_pmtable.Rd
+++ b/man/make_boot_pmtable.Rd
@@ -7,13 +7,16 @@
 make_boot_pmtable(
   .df,
   .pmtype = c("full", "fixed", "structural", "covariate", "random"),
+  .span_model_label = "Full model",
+  .span_boot_label = "Non-parametric bootstrap",
   .width = 1
 )
 }
 \arguments{
-\item{.df}{bootstrap parameter dataset and non-bootstrap parameter dataset combined.}
+\item{.df}{Combined dataset of model and bootstrap parameter estimates. See
+examples.}
 
-\item{.pmtype}{parameter table type. Options include:
+\item{.pmtype}{Parameter table type. Options include:
 \itemize{
 \item \code{"full"} (all rows in \code{.df} retained in pmtable). This is the default.
 \item \code{"fixed"} (all rows with type = "Struct" or "effect"),
@@ -22,7 +25,13 @@ make_boot_pmtable(
 \item \code{"random"} (all rows with greek = "Omega" or type = "Resid").
 }}
 
-\item{.width}{notes width. Defaults to 1.}
+\item{.span_model_label}{A label for the span above columns relating to the
+model that was bootstrapped.}
+
+\item{.span_boot_label}{A label for the span above columns relating to the
+confidence interval of bootstrap estimates.}
+
+\item{.width}{Notes width. Defaults to 1.}
 }
 \description{
 Generate a complete bootstrap parameter table ready for rendering via \code{pmtables}

--- a/tests/testthat/test-make-boot-pmtable.R
+++ b/tests/testthat/test-make-boot-pmtable.R
@@ -51,3 +51,27 @@ test_that("make_boot_pmtable: incorrect dataframe checks", {
     "No confidence intervals or percentiles for the bootstrap parameter estimates were detected"
   )
 })
+
+
+test_that("make_boot_pmtable correctly filters with .pmtype", {
+  model_label = "model stuff"
+  boot_label = "bootstrap stuff"
+
+  pm_tibble <- make_boot_pmtable(
+    BOOT_PARAM_TAB_106,
+    .span_model_label = model_label,
+    .span_boot_label = boot_label
+  )
+
+  expect_equal(pm_tibble$span[[1]]$title, model_label)
+  expect_equal(
+    names(pm_tibble$data %>% dplyr::select(!!pm_tibble$span[[1]]$vars)),
+    c("value", "shrinkage")
+  )
+  expect_equal(pm_tibble$span[[2]]$title, boot_label)
+  expect_equal(
+    names(pm_tibble$data %>% dplyr::select(!!pm_tibble$span[[2]]$vars)),
+    c("Median", "95\\% CI")
+  )
+
+})


### PR DESCRIPTION
 - Add `.drop_model_ci` argument for removing `ci_[x]` columns in `make_boot_pmtable`
    - Defaults to `TRUE`, which drops confidence interval columns of the original model from the combined dataframe
    - If `FALSE`, will rename the columns to "95% CI" during the rendering of the table, and ensure its grouping with the appropriate  span label (`.span_model_label`)
 - Add arguments for setting span labels in `make_boot_pmtable`
    - `.span_model_label`: A label for the span above columns relating to the model that was bootstrapped.
    - `.span_boot_label`: A label for the span above columns relating to the confidence interval of bootstrap estimates. 