### PR TITLE
Pass digits and maxex to internal functions and remove duplicate getpRSE call

### DIFF
--- a/R/formatValues.R
+++ b/R/formatValues.R
@@ -14,7 +14,7 @@ formatValues <- function(.df,
   .df %>%
     backTrans_log() %>%
     backTrans_logit() %>%
-    getpCV() %>%
+    getpCV(.digit = .digit, .maxex = .maxex) %>%
     dplyr::mutate(
       ci = paste0(display_value(lower, .digit, .maxex), ', ', display_value(upper, .digit, .maxex)),
       ci = dplyr::if_else(fixed, "FIXED", ci),

--- a/R/formatValues.R
+++ b/R/formatValues.R
@@ -15,7 +15,6 @@ formatValues <- function(.df,
     backTrans_log() %>%
     backTrans_logit() %>%
     getpCV() %>%
-    getpRSE() %>%
     dplyr::mutate(
       ci = paste0(display_value(lower, .digit, .maxex), ', ', display_value(upper, .digit, .maxex)),
       ci = dplyr::if_else(fixed, "FIXED", ci),
@@ -35,7 +34,7 @@ formatValues <- function(.df,
         !diag & S ~ glue::glue("{value} {parensSQ_corr(corr_SD)}"),
         TRUE ~ value),
       shrinkage = dplyr::case_when(is.na(shrinkage) ~ "-", TRUE ~ display_value(shrinkage, .digit, .maxex))
-    )
+    ) %>% suppressSpecificWarning("NAs introduced by coercion")
 }
 
 

--- a/R/format_param_table.R
+++ b/R/format_param_table.R
@@ -83,7 +83,7 @@ format_param_table <- function(
   .ci_level <- unique(.df[["ci_level"]])
   .ci_final_nam <- paste0("ci_", .ci_level)
 
-  if (isTRUE(.prse)) .df <- getpRSE(.df)
+  if (isTRUE(.prse)) .df <- getpRSE(.df, .digit = .digit, .maxex = .maxex)
 
   # Create formatted table
   .df_out <-

--- a/R/utils.R
+++ b/R/utils.R
@@ -73,3 +73,18 @@ stop_if_missing_deps <- function(pkgs = "bbr") {
     ), call. = FALSE)
   }
 }
+
+
+#' Suppress a warning that matches `.regexpr`
+#' @param .expr Expression to run
+#' @param .regexpr Regex to match against any generated warning. Warning will be
+#'  suppressed if this matches the warning message.
+#' @noRd
+suppressSpecificWarning <- function(.expr, .regexpr) {
+  withCallingHandlers({
+    .expr
+  }, warning=function(w) {
+    if (stringr::str_detect(w$message, .regexpr))
+      invokeRestart("muffleWarning")
+  })
+}

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -18,7 +18,7 @@ test_that("format_param_table expected dataframe: col names", {
   expect_equal(names(newDF3),  c("type", "abb", "greek", "desc", "value", "shrinkage", paste0("ci_", ci_name)))
 
   # all cols., no prse
-  expect_equal(length(names(newDF5)),  40)
+  expect_equal(length(names(newDF5)),  39)
 })
 
 test_that("format_param_table expected dataframe: prse col", {
@@ -26,7 +26,7 @@ test_that("format_param_table expected dataframe: prse col", {
   expect_equal(newDF4$pRSE[1],  "6.29")
   expect_true("pRSE" %in% names(newDF6))
 
-  expect_equal(length(names(newDF6)),  length(names(newDF5)))
+  expect_equal(length(names(newDF6)),  length(names(newDF5)) + 1)
   expect_true("pRSE" %in% names(newDF6))
 })
 
@@ -145,12 +145,12 @@ test_that("format_param_table: .digit produces expected significant digits", {
 
 test_that("format_param_table: .maxex produces expected scientific notation", {
 
-  newDF11 <- PARAM_TAB_102 %>%
+  param_df <- PARAM_TAB_102 %>%
     mutate(value = value*100,
            upper = upper*0.01,
            lower = lower*0.0001)
 
-  newDF12 <- format_param_table(newDF11)
+  newDF12 <- format_param_table(param_df)
   expect_equal(newDF12$value[1], "6.77e+18")
   expect_equal(newDF12$value[10], "13.4 [Corr=0.694]")
   expect_equal(newDF12$ci_95[10], "8.78e-06, 0.00180")
@@ -171,7 +171,7 @@ test_that("format_param_table: .select_cols works", {
     df2 <- format_param_table(PARAM_TAB_102, .select_cols = "ALL"),
     "is deprecated"
   )
-  expect_equal(setdiff(names(df2), names(PARAM_TAB_102)), c("cv", "pRSE", "sd", "text", "greek", "type", "type_f", "ci_95"))
+  expect_equal(setdiff(names(df2), names(PARAM_TAB_102)), c("cv", "sd", "text", "greek", "type", "type_f", "ci_95"))
 
   # Missing cols
   expect_error(

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -155,6 +155,21 @@ test_that("format_param_table: .maxex produces expected scientific notation", {
   expect_equal(newDF12$value[10], "13.4 [Corr=0.694]")
   expect_equal(newDF12$ci_95[10], "8.78e-06, 0.00180")
   expect_equal(newDF12$shrinkage[6], "18.2")
+
+  # Regression test: check that CV% and pRSE respect .maxex
+
+  # Check CV%
+  param_df <- PARAM_TAB_102 %>%
+    mutate(value = value*100, upper = upper*0.01, lower = lower*0.0001)
+
+  newDF13 <- format_param_table(param_df, .maxex = 2)
+  expect_equal(newDF13$value[6], "22.1 [CV\\%=6.17e+06]")
+
+  # Check pRSE
+  param_df <- PARAM_TAB_102 %>%
+    mutate(value = value*2, upper = upper*0.01, lower = lower*0.0001)
+  newDF13 <- format_param_table(param_df, .maxex = 2, .digit = 1, .prse = TRUE)
+  expect_equal(newDF13$pRSE[6], "1.e+01")
 })
 
 test_that("format_param_table: .select_cols works", {


### PR DESCRIPTION
 - Remove duplicate `getpRSE` call
   - This function is optionally called in formatValues, per the `.prse` argument. Previously this column was being appended always, and then just filtered out based on the .cleanup_cols or the deprecated .select_cols arguments. This did not align with the parameter documentation for the `.prse` argument, so I removed the duplicate call and adjusted test expectations.
 - Pass `.digits` and `.maxex` to `getpCV` and `getpRSE` functions
    - these `pmtables::sig()` arguments (named slightly differently) were not being passed to these functions previously. `CV%` labels and `pRSE` columns are now formatted correctly

closes https://github.com/metrumresearchgroup/pmparams/issues/106