### PR TITLE
update CI to point to MPN for magick

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,6 +22,8 @@ jobs:
         config:
           - os: ubuntu-20.04
             r: 4.0.5
+            # Latest magick requires R 4.1.
+            magick_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-02-26/src/contrib/magick_2.8.5.tar.gz'
           - os: ubuntu-20.04
             r: 4.1.3
           - os: ubuntu-latest
@@ -45,8 +47,8 @@ jobs:
           extra-packages: |
             any::pkgdown
             any::rcmdcheck
-            github::tidyverse/glue@v1.7.0
-          upgrade: 'TRUE'
+            ${{ matrix.config.magick_pkg }}
+          upgrade: ${{ matrix.config.r == '4.0.5' && 'FALSE' || 'TRUE' }}
       - uses: r-lib/actions/check-r-package@v2
       - name: Check pkgdown
         shell: Rscript {0}


### PR DESCRIPTION
 - CI was failing for R 4.05 because [magick now requires R 4.1](https://github.com/ropensci/magick/commit/2183c3f60fcf8f8e142eafe722a642f16169f48c)

 - remove outdated glue installation