### PR TITLE
upgrade ubuntu and increase tested R version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,7 +26,9 @@ jobs:
             # Latest magick requires R 4.1.
             magick_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-02-26/src/contrib/magick_2.8.5.tar.gz'
           - os: ubuntu-22.04
-            r: 4.3.1
+            r: 4.3.3
+          - os: ubuntu-22.04
+            r: 4.4.2
           - os: ubuntu-latest
             r: release
     env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,12 +20,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: ubuntu-20.04
+          - label: oldest
+            os: ubuntu-22.04
             r: 4.0.5
             # Latest magick requires R 4.1.
             magick_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-02-26/src/contrib/magick_2.8.5.tar.gz'
-          - os: ubuntu-20.04
-            r: 4.1.3
+          - os: ubuntu-22.04
+            r: 4.3.1
           - os: ubuntu-latest
             r: release
     env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,8 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - label: oldest
-            os: ubuntu-22.04
+          - os: ubuntu-22.04
             r: 4.0.5
             # Latest magick requires R 4.1.
             magick_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-02-26/src/contrib/magick_2.8.5.tar.gz'


### PR DESCRIPTION
upgrade ubuntu to 22.04 and increase a tested R version from R 4.1 to R 4.3 for the middle
 - Doesnt touch R versions for oldest or latest. 
 - We could bump oldest to R 4.1 to match MPN, though isnt necessary at this stage.