### PR TITLE
format_param_table: restore position of CI column after value column

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,8 +22,12 @@ jobs:
         config:
           - os: ubuntu-22.04
             r: 4.0.5
+            # gh 1.5.0 requires R 4.1.
+            gh_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-05-22/src/contrib/gh_1.4.1.tar.gz'
             # Latest magick requires R 4.1.
             magick_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-02-26/src/contrib/magick_2.8.5.tar.gz'
+            # scales 1.4.0 requires R 4.1.
+            scales_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-04-23/src/contrib/scales_1.3.0.tar.gz'
           - os: ubuntu-22.04
             r: 4.3.3
           - os: ubuntu-22.04
@@ -49,7 +53,9 @@ jobs:
           extra-packages: |
             any::pkgdown
             any::rcmdcheck
+            ${{ matrix.config.gh_pkg }}
             ${{ matrix.config.magick_pkg }}
+            ${{ matrix.config.scales_pkg }}
           upgrade: ${{ matrix.config.r == '4.0.5' && 'FALSE' || 'TRUE' }}
       - uses: r-lib/actions/check-r-package@v2
       - name: Check pkgdown

--- a/R/format_param_table.R
+++ b/R/format_param_table.R
@@ -119,7 +119,7 @@ format_param_table <- function(
     }
   } else {
     if (isTRUE(.cleanup_cols)) {
-      .select_cols <- c("type", "abb", "greek", "desc", "value", "shrinkage", .ci_final_nam)
+      .select_cols <- c("type", "abb", "greek", "desc", "value", .ci_final_nam, "shrinkage")
     } else {
       .select_cols <- names(.df_out)
     }

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -15,7 +15,7 @@ ci_name <- PARAM_TAB_102 %>% dplyr::distinct(ci_level) %>% dplyr::pull(ci_level)
 
 test_that("format_param_table expected dataframe: col names", {
   # default cols., no prse
-  expect_equal(names(newDF3),  c("type", "abb", "greek", "desc", "value", "shrinkage", paste0("ci_", ci_name)))
+  expect_equal(names(newDF3),  c("type", "abb", "greek", "desc", "value", paste0("ci_", ci_name), "shrinkage"))
 
   # all cols., no prse
   expect_equal(length(names(newDF5)),  39)


### PR DESCRIPTION
As of the 0.2.1 release, specifically 1e1f957 (2024-10-23, gh-74), format_param_table positions the CI column after the shrinkage column instead of the value column.

The value and interval are closely connected, and it makes sense to present them side by side.  Restore the CI column to its original position.

---

cc: @seth127 @graceannobrien @barrettk @KatherineKayMRG 