### PR TITLE
ci: pin purrr for R 4.0.5

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,6 +28,8 @@ jobs:
             magick_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-02-26/src/contrib/magick_2.8.5.tar.gz'
             # scales 1.4.0 requires R 4.1.
             scales_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-04-23/src/contrib/scales_1.3.0.tar.gz'
+            # purrr 1.1.0 requires R 4.1.
+            purrr_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-06-16/src/contrib/purrr_1.0.4.tar.gz'
           - os: ubuntu-22.04
             r: 4.3.3
           - os: ubuntu-22.04
@@ -56,6 +58,7 @@ jobs:
             ${{ matrix.config.gh_pkg }}
             ${{ matrix.config.magick_pkg }}
             ${{ matrix.config.scales_pkg }}
+            ${{ matrix.config.purrr_pkg }}
           upgrade: ${{ matrix.config.r == '4.0.5' && 'FALSE' || 'TRUE' }}
       - uses: r-lib/actions/check-r-package@v2
       - name: Check pkgdown


### PR DESCRIPTION
pin purrr for R 4.0.5 
- [purrr 1.1.0 requires R 4.1](https://github.com/tidyverse/purrr/releases/tag/v1.1.0)