### PR TITLE
fix: use case_when in formatValuesBoot to handle NA

### DIFF
--- a/R/formatValuesBoot.R
+++ b/R/formatValuesBoot.R
@@ -16,10 +16,9 @@ formatValuesBoot <- function(
     dplyr::mutate(
       boot_value = display_value(.data$value, .digit, .maxex),
       fixed = (.data$lower == .data$upper),
-      !!rlang::sym(ci_name) := dplyr::if_else(
-        .data$fixed,
-        "FIXED",
-        paste0(
+      !!rlang::sym(ci_name) := dplyr::case_when(
+        .data$fixed ~ "FIXED",
+        TRUE ~ paste0(
           display_value(.data$lower, .digit, .maxex), ', ',
           display_value(.data$upper, .digit, .maxex)
         )

--- a/tests/testthat/test-format_boot_table.R
+++ b/tests/testthat/test-format_boot_table.R
@@ -1,4 +1,3 @@
-
 newDF5 <- BOOT_TAB_106 %>%
   format_boot_table(.cleanup_cols = FALSE)
 
@@ -117,4 +116,19 @@ test_that("format_boot_table: .select_cols works", {
     format_boot_table(df1, .select_cols = "other") %>% suppressWarnings(),
     "The following specified columns were not found: other"
   )
+})
+
+
+test_that("formatValuesBoot handles NA in lower/upper", {
+  test_df <- tibble::tibble(
+    value = c(1, 2),
+    lower = c(0.9, NA),
+    upper = c(1.1, NA),
+    ci_level = c(95, 95)
+  )
+
+  res <- pmparams:::formatValuesBoot(test_df, .digit = 2, .maxex = 5)
+
+  expect_equal(res$boot_ci_95[1], "0.90, 1.1")
+  expect_equal(gsub(" ", "", res$boot_ci_95[2]), "NA,NA")
 })

--- a/tests/testthat/test-format_boot_table.R
+++ b/tests/testthat/test-format_boot_table.R
@@ -1,3 +1,4 @@
+
 newDF5 <- BOOT_TAB_106 %>%
   format_boot_table(.cleanup_cols = FALSE)
 


### PR DESCRIPTION
Addresses #117 

**Summary**

This PR fixes an issue in `formatValuesBoot` where `NA` values in the `fixed` column caused `NA`s in the `boot_ci` output.

**Details**

* Replaced `dplyr::if_else` with `dplyr::case_when` in `R/formatValuesBoot.R`.
  This ensures:

  * `boot_ci` is `"lower, upper"` when `fixed` is `FALSE` or `NA`.
  * `boot_ci` is `"FIXED"` when `fixed` is `TRUE`.

* Added a new test in `tests/testthat/test-format_boot_table.R` to validate `NA` handling in `lower` and `upper` columns.
  The test confirms `"NA,NA"` output (after whitespace removal) for `NA` `fixed` values.

**Verification**

All tests pass, including the new case verifying correct formatting for stochastic (`NA`) parameters.
