### PR TITLE
Render logit-transformed estimates with abbreviated expit() notation by default

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,16 +21,6 @@ jobs:
       matrix:
         config:
           - os: ubuntu-22.04
-            r: 4.0.5
-            # gh 1.5.0 requires R 4.1.
-            gh_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-05-22/src/contrib/gh_1.4.1.tar.gz'
-            # Latest magick requires R 4.1.
-            magick_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-02-26/src/contrib/magick_2.8.5.tar.gz'
-            # scales 1.4.0 requires R 4.1.
-            scales_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-04-23/src/contrib/scales_1.3.0.tar.gz'
-            # purrr 1.1.0 requires R 4.1.
-            purrr_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-06-16/src/contrib/purrr_1.0.4.tar.gz'
-          - os: ubuntu-22.04
             r: 4.3.3
           - os: ubuntu-22.04
             r: 4.4.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Description: `pmparams` is a library written in R that generates clear, well-for
 URL: https://metrumresearchgroup.github.io/pmparams/, https://github.com/metrumresearchgroup/pmparams
 BugReports: https://github.com/metrumresearchgroup/pmparams/issues
 Depends:
-    R (>= 3.5)
+    R (>= 4.1)
 Imports:
     checkmate,
     dplyr (>= 1.0.0),

--- a/R/formatGreekNames.R
+++ b/R/formatGreekNames.R
@@ -4,7 +4,7 @@
 #' Format THETA/OMEGA/SIGMA values to display as greek letters with subscript numbers.
 #'
 #' @keywords internal
-formatGreekNames <- function(.df){
+formatGreekNames <- function(.df, .expit = TRUE){
 
   .df %>%
     dplyr::mutate(greekName = name) %>%
@@ -28,7 +28,7 @@ formatGreekNames <- function(.df){
         TRUE ~ tolower(text)),
       greek = dplyr::case_when(
         TH & LOG ~ expGreek(text, num2),
-        TH & LOGIT ~ logitGreek(text, num2),
+        TH & LOGIT ~ logitGreek(text, num2, .expit),
         TRUE ~ mathMode(greekNum(gtGreek(text), num2))
       )
     ) %>% dplyr::select(-"num2")

--- a/R/formatGreekNames.R
+++ b/R/formatGreekNames.R
@@ -28,7 +28,7 @@ formatGreekNames <- function(.df, .expit = TRUE){
         TRUE ~ tolower(text)),
       greek = dplyr::case_when(
         TH & LOG ~ expGreek(text, num2),
-        TH & LOGIT ~ logitGreek(text, num2, .expit),
+        TH & LOGIT ~ logitGreek(text, num2, .expit = .expit),
         TRUE ~ mathMode(greekNum(gtGreek(text), num2))
       )
     ) %>% dplyr::select(-"num2")

--- a/R/format_param_table.R
+++ b/R/format_param_table.R
@@ -35,7 +35,7 @@
 #'   - Set to `FALSE` to return all columns.
 #' @param .prse Logical (T/F). If `TRUE`, output `pRSE`. Default is `FALSE`.
 #' @param .expit If `TRUE`, logit-trasformed parameters are rendered as
-#  `expit(...)`; if `FALSE`, use `exp(...)/(1+exp(...))`.
+#    `expit(...)`; if `FALSE`, use `exp(...)/(1+exp(...))`.
 #' @param .select_cols Deprecated. Please use `.cleanup_cols` instead.
 #'
 #' @examples

--- a/R/format_param_table.R
+++ b/R/format_param_table.R
@@ -34,7 +34,7 @@
 #'   - `"type"`, `"abb"`, `"greek"`, `"desc"`, `"value"`, `"ci"`, `"shrinkage"`.
 #'   - Set to `FALSE` to return all columns.
 #' @param .prse Logical (T/F). If `TRUE`, output `pRSE`. Default is `FALSE`.
-#' @param .expit If `TRUE`, logit-trasformed parameters will be rendered as
+#' @param .expit If `TRUE`, logit-trasformed parameters are rendered as
 #  `expit(...)`; if `FALSE`, use `exp(...)/(1+exp(...))`.
 #' @param .select_cols Deprecated. Please use `.cleanup_cols` instead.
 #'

--- a/R/format_param_table.R
+++ b/R/format_param_table.R
@@ -34,6 +34,8 @@
 #'   - `"type"`, `"abb"`, `"greek"`, `"desc"`, `"value"`, `"ci"`, `"shrinkage"`.
 #'   - Set to `FALSE` to return all columns.
 #' @param .prse Logical (T/F). If `TRUE`, output `pRSE`. Default is `FALSE`.
+#' @param .expit If `TRUE`, logit-trasformed parameters will be rendered as
+#  `expit(...)`; if `FALSE`, use `exp(...)/(1+exp(...))`.
 #' @param .select_cols Deprecated. Please use `.cleanup_cols` instead.
 #'
 #' @examples
@@ -70,6 +72,7 @@ format_param_table <- function(
     .df,
     .cleanup_cols = TRUE,
     .prse = FALSE,
+    .expit = TRUE,
     .digit = getOption("pmparams.dig"),
     .maxex = getOption("pmparams.maxex"),
     .select_cols = NULL
@@ -89,7 +92,7 @@ format_param_table <- function(
   .df_out <-
     .df %>%
     formatValues(.digit = .digit, .maxex = .maxex) %>%
-    formatGreekNames() %>%
+    formatGreekNames(.expit = .expit) %>%
     getPanelName() %>%
     dplyr::arrange(as.numeric(nrow))
 

--- a/R/greek-num.R
+++ b/R/greek-num.R
@@ -25,7 +25,7 @@ expGreek  <- function(.x, .y){
 #' @rdname mathMode
 #' @keywords internal
 logitGreek  <- function(.x, .y, .expit = TRUE){
-  if(isTRUE(expit)) {
+  if(isTRUE(.expit)) {
     code <- "$\\mathop{\\mathrm{expit}}(\\<<.x>>_{<<.y>>})$"
   } else {
     code <- "$\\exp(\\<<.x>>_{<<.y>>}) / \\newline(1 + \\exp(\\<<.x>>_{<<.y>>}))$"

--- a/R/greek-num.R
+++ b/R/greek-num.R
@@ -24,7 +24,12 @@ expGreek  <- function(.x, .y){
 
 #' @rdname mathMode
 #' @keywords internal
-logitGreek  <- function(.x, .y){
-  glue::glue("$\\exp(\\<<.x>>_{<<.y>>}) / \\newline(1 + \\exp(\\<<.x>>_{<<.y>>}))$", .open = "<<", .close  = ">>")
+logitGreek  <- function(.x, .y, .expit = TRUE){
+  if(isTRUE(expit)) {
+    code <- "$\\mathop{\\mathrm{expit}}(\\<<.x>>_{<<.y>>})$"
+  } else {
+    code <- "$\\exp(\\<<.x>>_{<<.y>>}) / \\newline(1 + \\exp(\\<<.x>>_{<<.y>>}))$"
+  }
+  glue::glue(code, .open = "<<", .close  = ">>")
 }
 

--- a/R/param-notes.R
+++ b/R/param-notes.R
@@ -56,7 +56,7 @@ param_notes <- function(.ci = 95, .zscore = NULL){
     cvSigmaEq = "CV\\% of sigma = sqrt(estimate) $\\cdot$ 100",
     logTrans = "Parameters estimated in the log domain were back-transformed for clarity",
     logitTrans = "Parameters estimated in the logit domain were back-transformed for clarity",
-    expitEq = "$\\mathop{\\mathrm{expit}}(estimate)$ = $\\exp(estimate)/(1+\\exp(estimate))$
+    expitEq = "$\\mathop{\\mathrm{expit}}$(estimate) = $\\exp$(estimate)/(1+$\\exp(estimate)$)"
   )
 }
 

--- a/R/param-notes.R
+++ b/R/param-notes.R
@@ -56,7 +56,7 @@ param_notes <- function(.ci = 95, .zscore = NULL){
     cvSigmaEq = "CV\\% of sigma = sqrt(estimate) $\\cdot$ 100",
     logTrans = "Parameters estimated in the log domain were back-transformed for clarity",
     logitTrans = "Parameters estimated in the logit domain were back-transformed for clarity",
-    expitEq = "$\\mathop{\\mathrm{expit}}$(estimate) = $\\exp$(estimate)/(1+$\\exp(estimate)$)"
+    expitEq = "$\\mathop{\\mathrm{expit}}$(estimate) = $\\exp$(estimate)/(1+$\\exp$(estimate))"
   )
 }
 

--- a/R/param-notes.R
+++ b/R/param-notes.R
@@ -55,7 +55,8 @@ param_notes <- function(.ci = 95, .zscore = NULL){
     cvOmegaEq = "CV\\% of log-normal omega = sqrt(exp(estimate) - 1) $\\cdot$ 100",
     cvSigmaEq = "CV\\% of sigma = sqrt(estimate) $\\cdot$ 100",
     logTrans = "Parameters estimated in the log domain were back-transformed for clarity",
-    logitTrans = "Parameters estimated in the logit domain were back-transformed for clarity"
+    logitTrans = "Parameters estimated in the logit domain were back-transformed for clarity",
+    expitEq = "$\\mathop{\\mathrm{expit}}(estimate)$ = $\\exp(estimate)/(1+\\exp(estimate))$
   )
 }
 

--- a/inst/model/nonmem/pk-parameter-key-logit.yaml
+++ b/inst/model/nonmem/pk-parameter-key-logit.yaml
@@ -1,0 +1,71 @@
+##' name = THETA, OMEGA, SIGMA
+##'
+##' abb = abbreviation you want to appear in the parameter table (use latex coding)
+##'
+##' desc = description you want to appear in the parameter table
+##'
+##' panel = indicate which panel each parameter should appear under.
+##' Current options include:
+##'   panel=="struct" ~ "Structural model parameters"
+##'   panel=="cov" ~ "Covariate effect parameters"
+##'   panel=="IIV" ~ "Interindividual covariance parameters" (off-diagonals << function takes care of this)
+##'   panel=="IIV" ~ "Interindividual variance parameters" (diagonals << function takes care of this)
+##'   panel=="IOV"  ~ "Interoccasion variance parameters"
+##'   panel=="RV" ~ "Residual variance"
+##'   Additional options can be added to `getPanelName` function in `functions-table.R`
+##'
+##' trans = define how do you want the parameter to be transformed
+##'   there are a finite options currently coded up (see below) but you're welcome
+##'   add new options. Current options include:
+##'        "none"       - untransformed parameters, e.g. THETAs or off-diagonals
+##'        "logTrans"   - THETAs estimated in the log domain
+##'        "logitTrans" - THETAs estimated using a logit transform
+##'        "lognormalOm"- for log-normal omegas e.g. CL = THETA(1) * exp(ETA(1)) - returns est.+CV%
+##'        "OmSD"       - for omegas where you want to return SD only - returns estimate & SD
+##'                     - use this for additive omegas e.g. CL = THETA(1) + ETA(1)
+##'        "logitOmSD"  - for omegas using logit transform - returns estimate & SD (calculated with logitnorm package)
+##'                     - this option requires you provide the associated THETA separated with a "~"
+##'                     - e.g. "logitOmSD ~ THETA3"
+##'        "addErr"     - for additive error terms (coded using THETA or SIGMA in $ERROR) - returns est.+ SD
+##'        "propErr"    - for proportional error terms (coded using THETA or SIGMA in $ERROR) - returns est.+CV%
+##'        "addErrLogDV" - for an additive error term on log-transformed data (coded using THETA or SIGMA in $ERROR) - returns est.+CV%
+#
+# paramKey = tribble(
+#   ~name, ~abb, ~desc, ~panel, ~trans,
+#   "THETA1",  "KA (1/h)", "First order absorption rate constant",   "struct", "logTrans",
+#   "THETA2", "V2/F (L)",  "Apparent central volume",                "struct", "logTrans",
+#   "THETA3", "CL/F (L/h)", "Apparent clearance",                    "struct", "logTrans",
+#   "THETA4", "V3/F (L)",  "Apparent peripheral volume",             "struct", "logTrans",
+#   "THETA5", "Q/F (L/h)", "Apparent intercompartmental clearance",  "struct", "logTrans",
+#   "THETA6", "$\\text{CL/F}_{eGFR}$", "eGFR effect on CL/F",        "cov",    "none",
+#   "THETA7", "$\\text{CL/F}_{AGE}$", "Age effect on CL/F",          "cov",    "none",
+#   "THETA8", "$\\text{CL/F}_{ALB}$", "Serum albumin effect on CL/F","cov",    "none",
+#
+#   "OMEGA11", "IIV-KA",   "Variance of absorption",     "IIV", "lognormalOm",
+#   "OMEGA22", "IIV-V2/F", "Variance of central volume", "IIV", "lognormalOm",
+#   "OMEGA33", "IIV-CL/F", "Variance of clearance",      "IIV", "lognormalOm",
+#
+#   "OMEGA21", "V2/F-KA", "Covariance of V2/F - KA",    "IIV", "none",
+#   "OMEGA31", "CL/F-KA", "Covariance of CL/F - KA",    "IIV", "none",
+#   "OMEGA32", "CL/F-V2/F", "Covariance of CL/F - V2/F","IIV", "none",
+#
+#   "SIGMA11", "Proportional", "Variance", "RV", "propErr"
+# )
+
+THETA1:
+  abb: "KA (1/h)"
+  desc: "First order absorption rate constant"
+  panel: struct
+  trans: logTrans
+THETA2:
+  name: THETA2
+  abb: "V2/F (L)"
+  desc: "Apparent central volume"
+  panel: struct
+  trans: none
+THETA3:
+  name: THETA3
+  abb: "F1"
+  desc: "Bioavailability"
+  panel: struct
+  trans: logitTrans

--- a/man/formatGreekNames.Rd
+++ b/man/formatGreekNames.Rd
@@ -4,7 +4,7 @@
 \alias{formatGreekNames}
 \title{Format THETA/OMEGA/SIGMA values}
 \usage{
-formatGreekNames(.df)
+formatGreekNames(.df, .expit = TRUE)
 }
 \description{
 Format THETA/OMEGA/SIGMA values to display as greek letters with subscript numbers.

--- a/man/format_param_table.Rd
+++ b/man/format_param_table.Rd
@@ -8,6 +8,7 @@ format_param_table(
   .df,
   .cleanup_cols = TRUE,
   .prse = FALSE,
+  .expit = TRUE,
   .digit = getOption("pmparams.dig"),
   .maxex = getOption("pmparams.maxex"),
   .select_cols = NULL
@@ -25,6 +26,8 @@ following columns:
 }}
 
 \item{.prse}{Logical (T/F). If \code{TRUE}, output \code{pRSE}. Default is \code{FALSE}.}
+
+\item{.expit}{If \code{TRUE}, logit-trasformed parameters will be rendered as}
 
 \item{.digit}{Number of significant digits. Default is three digits}
 

--- a/man/format_param_table.Rd
+++ b/man/format_param_table.Rd
@@ -27,7 +27,7 @@ following columns:
 
 \item{.prse}{Logical (T/F). If \code{TRUE}, output \code{pRSE}. Default is \code{FALSE}.}
 
-\item{.expit}{If \code{TRUE}, logit-trasformed parameters will be rendered as}
+\item{.expit}{If \code{TRUE}, logit-trasformed parameters are rendered as}
 
 \item{.digit}{Number of significant digits. Default is three digits}
 

--- a/man/mathMode.Rd
+++ b/man/mathMode.Rd
@@ -16,7 +16,7 @@ greekNum(.x, .y)
 
 expGreek(.x, .y)
 
-logitGreek(.x, .y)
+logitGreek(.x, .y, .expit = TRUE)
 }
 \description{
 Greek number helper functions

--- a/pmparams.Rproj
+++ b/pmparams.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: be06b938-7cf2-4da5-a7a8-1b6069d73a0f
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -44,10 +44,7 @@ PARAM_TAB_102 <- define_param_table(PARAM_EST_102, PARAM_KEY_DF)
 FMT_PARAM_TAB_102 <- format_param_table(PARAM_TAB_102)
 FMT_PARAM_TAB_102_PRSE <- format_param_table(PARAM_TAB_102, .prse = TRUE)
 
-PARAM_TAB_EXPIT <- define_param_table(PARAM_EST_102, PARAM_KEY_PATH_LOGIT)
-FORMATTED_EXPIT <- format_param_table(PARAM_TAB_EXPIT)
 PARAM_TAB_LOGIT <- define_param_table(PARAM_EST_102, PARAM_KEY_PATH_LOGIT)
-FORMATTED_LOGIT <- format_param_table(PARAM_TAB_LOGIT, .expit = FALSE)
 
 ### Data for testing boot param table ###
 # parameter estimates

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -32,7 +32,7 @@ PARAM_KEY_PATH <-  file.path(MODEL_DIR, "pk-parameter-key-new.yaml")
 PARAM_KEY_YAML <- yaml::yaml.load_file(PARAM_KEY_PATH)
 PARAM_KEY_PATH_DF <-  file.path(MODEL_DIR, "pk-parameter-key.yaml")
 PARAM_KEY_PATH_BOTH <-  file.path(MODEL_DIR, "pk-parameter-key-both.yaml")
-
+PARAM_KEY_PATH_LOGIT <-  file.path(MODEL_DIR, "pk-parameter-key-logit.yaml")
 
 ### Data for testing param table (no bootstrap) ###
 MOD102_PATH <- file.path(MODEL_DIR, "102")
@@ -43,6 +43,11 @@ PARAM_EST_102 <- readr::read_csv(
 PARAM_TAB_102 <- define_param_table(PARAM_EST_102, PARAM_KEY_DF)
 FMT_PARAM_TAB_102 <- format_param_table(PARAM_TAB_102)
 FMT_PARAM_TAB_102_PRSE <- format_param_table(PARAM_TAB_102, .prse = TRUE)
+
+PARAM_TAB_EXPIT <- define_param_table(PARAM_EST_102, PARAM_KEY_PATH_LOGIT)
+FORMATTED_EXPIT <- format_param_table(PARAM_TAB_EXPIT)
+PARAM_TAB_LOGIT <- define_param_table(PARAM_EST_102, PARAM_KEY_PATH_LOGIT)
+FORMATTED_LOGIT <- format_param_table(PARAM_TAB_LOGIT, .expit = FALSE)
 
 ### Data for testing boot param table ###
 # parameter estimates

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -150,6 +150,9 @@ test_that("format_param_table: format logit greek via .expit", {
 
   expect_equal(nrow(logit), 3)
   expect_match(logit$greek[3], "1 + \\exp", fixed = TRUE)
+
+  eq <- param_notes()$expitEq
+  expect_match(eq, "expit")
 })
 
 test_that("format_param_table: .digit produces expected significant digits", {

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -130,6 +130,12 @@ test_that("format_param_table: logit back transform large estimate returns 1", {
 })
 
 
+test_that("format_param_table: .expit produces the correct label", {
+  
+  newDF9 <- format_param_table(PARAM_TAB_102)
+  
+)
+
 test_that("format_param_table: .digit produces expected significant digits", {
 
   newDF9 <- format_param_table(PARAM_TAB_102)

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -130,11 +130,31 @@ test_that("format_param_table: logit back transform large estimate returns 1", {
 })
 
 
-test_that("format_param_table: .expit produces the correct label", {
-  
-  newDF9 <- format_param_table(PARAM_TAB_102)
-  
-)
+test_that("format_param_table: format logit greek via .expit", {
+
+  expect_true(".expit" %in% names(formals(pmparams::format_param_table)))
+  expect_true(".expit" %in% names(formals(pmparams:::formatGreekNames)))
+  expect_true(".expit" %in% names(formals(pmparams:::logitGreek)))
+
+  expect_true(formals(pmparams:::formatGreekNames)$.expit)
+  expect_true(formals(pmparams:::logitGreek)$.expit)
+  expect_true(formals(pmparams:::format_param_table)$.expit)
+
+  expit <- pmparams:::logitGreek("theta", 5)
+  expect_equal(expit, "$\\mathop{\\mathrm{expit}}(\\theta_{5})$")
+
+  logit <- pmparams:::logitGreek("theta", 5, .expit = FALSE)
+  expect_equal(logit, "$\\exp(\\theta_{5}) / \\newline(1 + \\exp(\\theta_{5}))$")
+
+  expit <- format_param_table(PARAM_TAB_LOGIT)
+  logit <- format_param_table(PARAM_TAB_LOGIT, .expit = FALSE)
+
+  expect_equal(nrow(expit), 3)
+  expect_match(expit$greek[3], "\\mathrm{expit}", fixed = TRUE)
+
+  expect_equal(nrow(logit), 3)
+  expect_match(logit$greek[3], "1 + \\exp", fixed = TRUE)
+})
 
 test_that("format_param_table: .digit produces expected significant digits", {
 

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -132,13 +132,9 @@ test_that("format_param_table: logit back transform large estimate returns 1", {
 
 test_that("format_param_table: format logit greek via .expit", {
 
-  expect_true(".expit" %in% names(formals(pmparams::format_param_table)))
-  expect_true(".expit" %in% names(formals(pmparams:::formatGreekNames)))
-  expect_true(".expit" %in% names(formals(pmparams:::logitGreek)))
-
-  expect_true(formals(pmparams:::formatGreekNames)$.expit)
-  expect_true(formals(pmparams:::logitGreek)$.expit)
-  expect_true(formals(pmparams:::format_param_table)$.expit)
+  expect_true(formals(pmparams:::formatGreekNames)[[".expit"]])
+  expect_true(formals(pmparams:::logitGreek)[[".expit"]])
+  expect_true(formals(pmparams:::format_param_table)[[".expit"]])
 
   expit <- pmparams:::logitGreek("theta", 5)
   expect_equal(expit, "$\\mathop{\\mathrm{expit}}(\\theta_{5})$")

--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -150,9 +150,6 @@ test_that("format_param_table: format logit greek via .expit", {
 
   expect_equal(nrow(logit), 3)
   expect_match(logit$greek[3], "1 + \\exp", fixed = TRUE)
-
-  eq <- param_notes()$expitEq
-  expect_match(eq, "expit")
 })
 
 test_that("format_param_table: .digit produces expected significant digits", {

--- a/tests/testthat/test-param-notes.R
+++ b/tests/testthat/test-param-notes.R
@@ -18,7 +18,8 @@ test_that("param_notes expected output: alpha",{
 
 test_that("param_notes expected output: footnotes",{
   eq4 <- param_notes()
-  expect_equal(11, length(eq4))
+  expect_equal(12, length(eq4))
   expect_equal(anyNA(eq4), FALSE)
   expect_equal(eq4$cvOmegaEq,"CV\\% of log-normal omega = sqrt(exp(estimate) - 1) $\\cdot$ 100")
+  expect_equal(eq4$expitEq, "$\\mathop{\\mathrm{expit}}$(estimate) = $\\exp$(estimate)/(1+$\\exp$(estimate))")
 })


### PR DESCRIPTION
- `.expit` argument defaults to `TRUE`
- Added to `format_param_table()`; passed through to `formatGreekNames()` and `logitGreek()`
- Added `inst/model/nonmem/pk-parameter-key-logit.yaml` for testing
- Added `expitEq` to the `param_notes()` output

<img width="524" height="513" alt="Screenshot 2026-04-02 at 10 25 00" src="https://github.com/user-attachments/assets/99071a98-f3c2-4599-93df-47d7142f031a" />

