### PR TITLE
github actions cleanup

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,11 +15,13 @@ env:
 jobs:
   check:
     runs-on: ${{ matrix.config.os }}
-    name: ${{ matrix.config.os }} R ${{ matrix.config.r }} ${{ matrix.config.label }}
+    name: ${{ matrix.config.os }} R ${{ matrix.config.r }}
     strategy:
       fail-fast: false
       matrix:
         config:
+          - os: ubuntu-22.04
+            r: 4.1.3
           - os: ubuntu-22.04
             r: 4.3.3
           - os: ubuntu-22.04
@@ -45,11 +47,7 @@ jobs:
           extra-packages: |
             any::pkgdown
             any::rcmdcheck
-            ${{ matrix.config.gh_pkg }}
-            ${{ matrix.config.magick_pkg }}
-            ${{ matrix.config.scales_pkg }}
-            ${{ matrix.config.purrr_pkg }}
-          upgrade: ${{ matrix.config.r == '4.0.5' && 'FALSE' || 'TRUE' }}
+          upgrade: 'TRUE'
       - uses: r-lib/actions/check-r-package@v2
       - name: Check pkgdown
         shell: Rscript {0}


### PR DESCRIPTION
Removed the stale matrix references (label, gh_pkg, magick_pkg, scales_pkg, purrr_pkg, and the 4.0.5 upgrade branch) so the matrix only contains fields that are actually defined and consumed. 

Also added an explicit ubuntu-22.04 / R 4.1.3 job, which makes the DESCRIPTION consistent with CI coverage.