### PR TITLE
test-format_param_table.R: update expected sig output

### DIFF
--- a/tests/testthat/test-format_param_table.R
+++ b/tests/testthat/test-format_param_table.R
@@ -191,7 +191,12 @@ test_that("format_param_table: .maxex produces expected scientific notation", {
   param_df <- PARAM_TAB_102 %>%
     mutate(value = value*2, upper = upper*0.01, lower = lower*0.0001)
   newDF13 <- format_param_table(param_df, .maxex = 2, .digit = 1, .prse = TRUE)
-  expect_equal(newDF13$pRSE[6], "1.e+01")
+  if (packageVersion("pmtables") >= "0.11.0") {
+    prse_expect <- "10"
+  } else {
+    prse_expect <- "1.e+01"
+  }
+  expect_equal(newDF13$pRSE[6], prse_expect)
 })
 
 test_that("format_param_table: .select_cols works", {


### PR DESCRIPTION
pmtables 0.11.0 reworked the sig function, which included a fix for a case triggered by a pmparams test:

    > pmtables:::sig_legacy("10.4", maxex = 2, digits = 1)
    [1] "1.e+01"

    > pmtables::sig("10.4", maxex = 2, digits = 1)
    [1] "10"

Re: https://github.com/metrumresearchgroup/pmtables/pull/378