### PR TITLE
Release 0.3.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pmparams
 Title: R package for parameter tables
-Version: 0.3.2
+Version: 0.3.3
 Authors@R: 
       c(person(given = "Katherine",
              family = "Kay",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
  - Added `.expit` argument to `format_param_table()` for controlling formatting of
  logit-transformed parameters. (#119)
  - Adjust test expectation associated with recent `pmtables::sig()` refactor (#122)
+ - Bump R version requirement to R 4.1 (#119)
 
 
 # pmparams 0.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,9 +3,8 @@
 ## Changes
  - Added `.expit` argument to `format_param_table()` for controlling formatting of
  logit-transformed parameters. (#119)
- 
-## Bug fixes
- - Fix test expectation associated with recent `pmtables::sig()` refactor (#122)
+ - Adjust test expectation associated with recent `pmtables::sig()` refactor (#122)
+
 
 # pmparams 0.3.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# pmparams 0.3.3
+
+## Changes
+ - Added `.expit` argument to `format_param_table()` for controlling formatting of
+ logit-transformed parameters. (#119)
+ 
+## Bug fixes
+ - Fix test expectation associated with recent `pmtables::sig()` refactor (#122)
+
 # pmparams 0.3.2
 
 ## Changes


### PR DESCRIPTION
[Changeset](https://github.com/metrumresearchgroup/pmparams/compare/0.3.2...release/0.3.3)

scores:
{
  "testing": {
    "check": 1,
    "coverage": 0.9038
  },
  "documentation": {
    "has_vignettes": 1,
    "has_website": 1,
    "has_news": 1
  },
  "maintenance": {
    "has_maintainer": 1,
    "news_current": 1
  },
  "transparency": {
    "has_source_control": 1,
    "has_bug_reports_url": 1
  }
}